### PR TITLE
Fix for GTP-U header length issue

### DIFF
--- a/src/gtp/gtp_encode.cpp
+++ b/src/gtp/gtp_encode.cpp
@@ -91,7 +91,8 @@ bool EncodeGtpMessage(const GtpMessage &gtp, OctetString &stream)
     stream.append(gtp.payload);
 
     // assigning length field
-    int length = stream.length() - initialLength;
+    // Length will not include GTP mandatory header, so subtract 8.
+    int length = stream.length() - initialLength - 8;
     stream.data()[initialLength + 2] = (uint8_t)(length >> 8 & 0xFF);
     stream.data()[initialLength + 3] = (uint8_t)(length & 0xFF);
 


### PR DESCRIPTION
Problem
=======
The length field in the GTPU header for the T-PDU packet is populated wrongly. The length value should not include the size of the mandatory GTPU header. 

Fix
==
Subtract 8 from the length value. Size of the mandatory GTPU header is 8.
