### PR TITLE
Quick solution for mnc values bug

### DIFF
--- a/src/gnb.cpp
+++ b/src/gnb.cpp
@@ -22,6 +22,7 @@
 #include <utils/options.hpp>
 #include <utils/yaml_utils.hpp>
 #include <yaml-cpp/yaml.h>
+#include <string>
 
 static app::CliServer *g_cliServer = nullptr;
 static nr::gnb::GnbConfig *g_refConfig = nullptr;
@@ -41,8 +42,10 @@ static nr::gnb::GnbConfig *ReadConfigYaml()
 
     result->plmn.mcc = yaml::GetInt32(config, "mcc", 1, 999);
     yaml::GetString(config, "mcc", 3, 3);
-    result->plmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
     result->plmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
+    auto mncValue = config["mnc"].Scalar();
+    config["mnc"] = mncValue.erase(0, std::min(mncValue.find_first_not_of('0'), mncValue.size()-1));
+    result->plmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
 
     result->nci = yaml::GetInt64(config, "nci", 0, 0xFFFFFFFFFll);
     result->gnbIdLength = yaml::GetInt32(config, "idLength", 22, 32);

--- a/src/gnb.cpp
+++ b/src/gnb.cpp
@@ -22,7 +22,6 @@
 #include <utils/options.hpp>
 #include <utils/yaml_utils.hpp>
 #include <yaml-cpp/yaml.h>
-#include <string>
 
 static app::CliServer *g_cliServer = nullptr;
 static nr::gnb::GnbConfig *g_refConfig = nullptr;
@@ -42,10 +41,8 @@ static nr::gnb::GnbConfig *ReadConfigYaml()
 
     result->plmn.mcc = yaml::GetInt32(config, "mcc", 1, 999);
     yaml::GetString(config, "mcc", 3, 3);
-    result->plmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
-    auto mncValue = config["mnc"].Scalar();
-    config["mnc"] = mncValue.erase(0, std::min(mncValue.find_first_not_of('0'), mncValue.size()-1));
     result->plmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
+    result->plmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
 
     result->nci = yaml::GetInt64(config, "nci", 0, 0xFFFFFFFFFll);
     result->gnbIdLength = yaml::GetInt32(config, "idLength", 22, 32);

--- a/src/utils/yaml_utils.cpp
+++ b/src/utils/yaml_utils.cpp
@@ -40,8 +40,12 @@ void AssertHasFields(const YAML::Node &node, const std::vector<std::string> &fie
 
 int GetInt32(const YAML::Node &node, const std::string &name)
 {
-    AssertHasInt32(node, name);
-    return node[name].as<int>();
+    auto nodeValue = node[name].Scalar();
+    nodeValue.erase(0, std::min(nodeValue.find_first_not_of('0'), nodeValue.size()-1));
+    YAML::Node modifiedNode;
+    modifiedNode[name] = nodeValue;
+    AssertHasInt32(modifiedNode, name);
+    return modifiedNode[name].as<int>();
 }
 
 int GetInt32(const YAML::Node &node, const std::string &name, std::optional<int> minValue, std::optional<int> maxValue)


### PR DESCRIPTION
Hi @aligungr, this pull request refers to [this issue](https://github.com/aligungr/UERANSIM/issues/350). Basically, the C++ compiler treat number starting with '0' as octal and so for mnc values from '01' to '07' there is no problem, but for '08' and '09' it gives an error because 8 and 9 are not allowed in octal notation.
The quickest solution, could be to check the length of mnc, and after that remove leading 0 in order to be able to convert it to an integer. I am not a C++ master (i haven't used it much) so this solution is likely to be improved.

Regards