### PR TITLE
Allow imsi less than 15 digits long

### DIFF
--- a/src/utils/common_types.cpp
+++ b/src/utils/common_types.cpp
@@ -19,7 +19,7 @@ Supi Supi::Parse(const std::string &supi)
     if (supi[0] == 'i' && supi[1] == 'm' && supi[2] == 's' && supi[3] == 'i' && supi[4] == '-')
     {
         std::string val = supi.substr(5);
-        if (val.size() != 15)
+        if (val.size() > 15)
             throw std::runtime_error("invalid IMSI value");
         for (char c : val)
             if (c < '0' || c > '9')


### PR DESCRIPTION
According to 3GPP 23.003, imsi can not exceed 15 digits, but can be less than 15 digits.