### PR TITLE
Consecutive ps-release commands will make gnb crash

### DIFF
--- a/src/gnb/gtp/task.cpp
+++ b/src/gnb/gtp/task.cpp
@@ -143,7 +143,7 @@ void GtpTask::handleSessionRelease(int ueId, int psi)
     m_rateLimiter->updateUeDownlinkLimit(ueId, 0);
 
     
-    if (!m_pduSessions[sessionInd]->downTunnel) {
+    if (m_pduSessions[sessionInd] == nullptr ) {
          m_logger->err("PDU session resource could not be released, PSI downlink tunnel [%d] not found", psi);
         return;
     }


### PR DESCRIPTION
Hi @aligungr 
We execute the ps-release commands twice will lead the gnb to get null pointer exception 

./nr-cli imsi-208930000000003   -e "ps-release-all";./nr-cli imsi-208930000000003   -e "ps-release-all"

**Root Cause**
null pointer exeption

gdb log
#0  nr::gnb::GtpTask::handleSessionRelease (
    this=0x555555b4e070, ueId=2, psi=1)
    at /home/ubuntu/UERANSIM/src/gnb/gtp/task.cpp:145
#1  0x000055555569cbb1 in nr::gnb::GtpTask::onLoop (
    this=0x555555b4e070)
    at /home/ubuntu/UERANSIM/src/gnb/gtp/task.cpp:74
#2  0x00005555558572e6 in NtsTask::<lambda()>::operator()(void) const (__closure=0x555555b56248)
    at /home/ubuntu/UERANSIM/src/utils/nts.cpp:219
#3  0x0000555555857a94 in std::__invoke_impl<void, NtsTask::start()::<lambda()> >(std::__invoke_other, NtsTask::<lambda()> &&) (__f=...) at /usr/include/c++/9/bits/invoke.h:60
#4  0x0000555555857a49 in std::__invoke<NtsTask::start()::<lambda()> >(NtsTask::<lambda()> &&) (__fn=...)
    at /usr/include/c++/9/bits/invoke.h:95
--Type <RET> for more, q to quit, c to continue without paging--
#5  0x00005555558579f6 in std::thread::_Invoker<std::tuple<NtsTask::start()::<lambda()> > >::_M_invoke<0>(std::_Index_tuple<0>) (this=0x555555b56248)
    at /usr/include/c++/9/thread:244
#6  0x00005555558579cc in std::thread::_Invoker<std::tuple<NtsTask::start()::<lambda()> > >::operator()(void) (
    this=0x555555b56248) at /usr/include/c++/9/thread:251
#7  0x00005555558579b0 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<NtsTask::start()::<lambda()> > > >::_M_run(void) (this=0x555555b56240)
    at /usr/include/c++/9/thread:195
#8  0x00007ffff7e8dde4 in ?? ()
   from /lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x00007ffff7fa7609 in start_thread (
    arg=<optimized out>) at pthread_create.c:477
#10 0x00007ffff7b7d293 in clone ()
    at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95


**Fix**
Check null pointer

**The result after this pull request**

<img width="925" alt="螢幕擷取畫面 2021-10-08 215546" src="https://user-images.githubusercontent.com/3509337/136569801-103c8330-d818-49ca-bdc9-73ca94edc812.png">


