### PR TITLE
fix EIA3 reading data byte-order

### DIFF
--- a/src/lib/crypt/eea3.cpp
+++ b/src/lib/crypt/eea3.cpp
@@ -61,10 +61,17 @@ uint32_t EIA3(const uint8_t *pKey, uint32_t count, uint32_t direction, uint32_t 
     z = new uint32_t[L];
     ZUC(pKey, IV, z, L);
 
+
+    uint32_t data_htobe32[length/32+1];
+    for (int i=0; i<(length+31)/32; i++)
+        data_htobe32[i] = htobe32(*(pData+i));
+
+    uint32_t *pData_htobe32 = data_htobe32;
+
     T = 0;
     for (i = 0; i < length; i++)
     {
-        if (GetBit(pData, i))
+        if (GetBit(pData_htobe32, i))
             T ^= GetWord(z, i);
     }
 
@@ -105,7 +112,7 @@ void EEA3(const uint8_t *pKey, uint32_t count, uint32_t bearer, uint32_t directi
 
     ZUC(pKey, iv, z, L);
     for (i = 0; i < L; i++)
-        pData[i] ^= z[i];
+        pData[i] = be32toh(htobe32(*(pData+i)) ^ z[i]);
     delete[] z;
 }
 


### PR DESCRIPTION
This PR fix the problem in NEA3 and NIA3 algorithm

The data used to computing EEA3 & EIA3 should be in bid-endian form, which is declared in 128-EEA3 & 128-EIA3 spec (https://www.gsma.com/security/wp-content/uploads/2019/05/EEA3_EIA3_specification_v1_8.pdf)

In order to make it perform correctly, data should be converted to network-byte order from host-byte order (may be little-endian based on different cpu) befor using it.

Before:
(ueransim_log)
![image](https://user-images.githubusercontent.com/37137430/140006555-16d6ad6c-36f6-4fb6-a18b-7d8e35e2508c.png)
(wireshark)
![image](https://user-images.githubusercontent.com/37137430/140006570-eeca6553-6595-4305-b1d6-d6fa35f9e0ce.png)

After:
(ueransim_log)
![image](https://user-images.githubusercontent.com/37137430/140006588-bf9fc64a-a3b6-48a3-92dc-8d7dd82e5506.png)
(wireshark)
![image](https://user-images.githubusercontent.com/37137430/140006609-09a80b7b-69a1-450e-b83e-6048821e6b2f.png)

