### PR TITLE
Enable IPv6 on n2 link (amf)

### DIFF
--- a/src/gnb.cpp
+++ b/src/gnb.cpp
@@ -49,7 +49,7 @@ static nr::gnb::GnbConfig *ReadConfigYaml()
     result->tac = yaml::GetInt32(config, "tac", 0, 0xFFFFFF);
 
     result->portalIp = yaml::GetIp(config, "linkIp");
-    result->ngapIp = yaml::GetIp4(config, "ngapIp");
+    result->ngapIp = yaml::GetIp(config, "ngapIp");
     result->gtpIp = yaml::GetIp4(config, "gtpIp");
 
     if (yaml::HasField(config, "gtpAdvertiseIp"))
@@ -63,7 +63,7 @@ static nr::gnb::GnbConfig *ReadConfigYaml()
     for (auto &amfConfig : yaml::GetSequence(config, "amfConfigs"))
     {
         nr::gnb::GnbAmfConfig c{};
-        c.address = yaml::GetIp4(amfConfig, "address");
+        c.address = yaml::GetIp(amfConfig, "address");
         c.port = static_cast<uint16_t>(yaml::GetInt32(amfConfig, "port", 1024, 65535));
         result->amfConfigs.push_back(c);
     }

--- a/src/gnb/types.cpp
+++ b/src/gnb/types.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 
 #include <gnb/types.hpp>
+#include <utils/common.hpp>
 
 namespace nr::gnb
 {
@@ -38,7 +39,7 @@ Json ToJson(const NgapAmfContext &v)
     return Json::Obj({
         {"id", v.ctxId},
         {"name", v.amfName},
-        {"address", v.address + ":" + std::to_string(v.port)},
+        {"address", ((utils::GetIpVersion(v.address) == 6) ? "[" + v.address + "]" : v.address) + ":" + std::to_string(v.port)},
         {"state", ToJson(v.state).str()},
         {"capacity", v.relativeCapacity},
         {"association", ToJson(v.association)},

--- a/src/lib/sctp/internal.cpp
+++ b/src/lib/sctp/internal.cpp
@@ -63,7 +63,13 @@ void BindSocket(int sd, const std::string &address, uint16_t port)
             ThrowError("Bad IPv4 address.");
     }
     else if (ipVersion == 6)
-        ThrowError("IPv6 for SCTP is not supported yet.");
+    {
+        auto addr6 = (sockaddr_in6 *)addr;
+        addr6->sin6_family = AF_INET6;
+        addr6->sin6_port = htons(port);
+        if (inet_pton(AF_INET6, address.c_str(), &(addr6->sin6_addr)) != 1)
+            ThrowError("Bad IPv6 address.");
+    }
     else
         ThrowError("Bad IPv4 or IPv6 address.");
 


### PR DESCRIPTION
- [x] Tested with free5gc's amf
- [ ] Requires #444 to be merged first, then a rebase (because of `yaml::GetIp`) 