### PR TITLE
Allow using FQDN along with IPv4 and IPv6

### DIFF
--- a/src/utils/io.cpp
+++ b/src/utils/io.cpp
@@ -251,12 +251,6 @@ std::string GetIp6OfInterface(const std::string &ifName)
 
 std::string GetHostByName(const std::string &name)
 {
-    struct addrinfo hints = {};
-
-    hints.ai_family = PF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags |= AI_CANONNAME;
-
     auto* res = gethostbyname(name.c_str());
     if (res == nullptr)
         return "";
@@ -270,7 +264,7 @@ std::string GetHostByName(const std::string &name)
             return "";
         return std::string{str};
     }
-    else if (res->h_addrtype == AF_INET)
+    else if (res->h_addrtype == AF_INET6)
     {
         char str[INET6_ADDRSTRLEN] = {0};
         if (inet_ntop(AF_INET6, res->h_addr_list[0], str, INET6_ADDRSTRLEN) == nullptr)

--- a/src/utils/io.cpp
+++ b/src/utils/io.cpp
@@ -251,28 +251,39 @@ std::string GetIp6OfInterface(const std::string &ifName)
 
 std::string GetHostByName(const std::string &name)
 {
-    auto* res = gethostbyname(name.c_str());
-    if (res == nullptr)
-        return "";
-    if (res->h_addr_list == nullptr)
+    struct addrinfo hints = {};
+    struct addrinfo *res;
+
+    hints.ai_family = AF_UNSPEC;
+
+    if (getaddrinfo(name.c_str(), NULL, &hints, &res))
         return "";
 
-    if (res->h_addrtype == AF_INET)
+    if (res->ai_family == AF_INET)
     {
         char str[INET_ADDRSTRLEN] = {0};
-        if (inet_ntop(AF_INET, res->h_addr_list[0], str, INET_ADDRSTRLEN) == nullptr)
+        if (inet_ntop(AF_INET, &((struct sockaddr_in*)res->ai_addr)->sin_addr, str, INET_ADDRSTRLEN) == nullptr)
+        {
+            freeaddrinfo(res);
             return "";
+        }
+        freeaddrinfo(res);
         return std::string{str};
     }
-    else if (res->h_addrtype == AF_INET6)
+    else if (res->ai_family == AF_INET6)
     {
         char str[INET6_ADDRSTRLEN] = {0};
-        if (inet_ntop(AF_INET6, res->h_addr_list[0], str, INET6_ADDRSTRLEN) == nullptr)
+        if (inet_ntop(AF_INET6, &((struct sockaddr_in6*)res->ai_addr)->sin6_addr, str, INET6_ADDRSTRLEN) == nullptr)
+        {
+            freeaddrinfo(res);
             return "";
+        }
+        freeaddrinfo(res);
         return std::string{str};
     }
     else
     {
+        freeaddrinfo(res);
         return "";
     }
 }

--- a/src/utils/yaml_utils.cpp
+++ b/src/utils/yaml_utils.cpp
@@ -146,15 +146,17 @@ std::string GetIp4(const YAML::Node &node, const std::string &name)
 {
     std::string s = GetString(node, name);
 
+    s = io::GetHostByName(s);
+
     int version = utils::GetIpVersion(s);
     if (version == 6)
-        FieldError(name, "must be a valid IPv4 address or a valid network interface with a IPv4 address");
+        FieldError(name, "must be a valid IPv4 address, FQDN or a valid network interface with a IPv4 address");
     if (version == 4)
         return s;
 
     auto ipFromIf = io::GetIp4OfInterface(s);
     if (ipFromIf.empty())
-        FieldError(name, "must be a valid IPv4 address or a valid network interface with a IPv4 address");
+        FieldError(name, "must be a valid IPv4 address, FQDN or a valid network interface with a IPv4 address");
     return ipFromIf;
 }
 
@@ -162,21 +164,25 @@ std::string GetIp6(const YAML::Node &node, const std::string &name)
 {
     std::string s = GetString(node, name);
 
+    s = io::GetHostByName(s);
+
     int version = utils::GetIpVersion(s);
     if (version == 4)
-        FieldError(name, "must be a valid IPv6 address or a valid network interface with a IPv6 address");
+        FieldError(name, "must be a valid IPv6 address, FQDN or a valid network interface with a IPv6 address");
     if (version == 6)
         return s;
 
     auto ipFromIf = io::GetIp6OfInterface(s);
     if (ipFromIf.empty())
-        FieldError(name, "must be a valid IPv6 address or a valid network interface with a IPv6 address");
+        FieldError(name, "must be a valid IPv6 address, FQDN or a valid network interface with a IPv6 address");
     return ipFromIf;
 }
 
 std::string GetIp(const YAML::Node &node, const std::string & name)
 {
     std::string s = GetString(node, name);
+
+    s = io::GetHostByName(s);
 
     int version = utils::GetIpVersion(s);
     if (version == 6 || version == 4)
@@ -187,7 +193,7 @@ std::string GetIp(const YAML::Node &node, const std::string & name)
     auto ip6FromIf = io::GetIp6OfInterface(s);
     if (!ip6FromIf.empty())
         return ip6FromIf;
-    FieldError(name, "must be a valid IP address or a valid network interface with an IP address");
+    FieldError(name, "must be a valid IP address, FQDN or a valid network interface with an IP address");
 }
 
 void AssertHasBool(const YAML::Node &node, const std::string &name)


### PR DESCRIPTION
This allows a name resolution attempt before checking IP versions.
GetHostByName is already implemented but never been used. When used
against an IP, it will yield the same IP. Therefore no regression
would be implied by this.

When the name resolution returns multiple IPv4 and IPv6 addresses,
GetHostByName only returns the first element of the list which
potentially is going to be an IPv4. This is not very convenient to
have inside GetIp6, but the user can always specify manually the
IPv6 to be used in the config file.