### PR TITLE
Global gNodeB ID bug fix

### DIFF
--- a/src/gnb/ngap/interface.cpp
+++ b/src/gnb/ngap/interface.cpp
@@ -122,7 +122,8 @@ void NgapTask::sendNgSetupRequest(int amfId)
 
     auto *globalGnbId = asn::New<ASN_NGAP_GlobalGNB_ID>();
     globalGnbId->gNB_ID.present = ASN_NGAP_GNB_ID_PR_gNB_ID;
-    asn::SetBitString(globalGnbId->gNB_ID.choice.gNB_ID, octet4{m_base->config->getGnbId()},
+    asn::SetBitString(globalGnbId->gNB_ID.choice.gNB_ID,
+                      octet4{m_base->config->getGnbId() << (32 - m_base->config->gnbIdLength)},
                       static_cast<size_t>(m_base->config->gnbIdLength));
     asn::SetOctetString3(globalGnbId->pLMNIdentity, ngap_utils::PlmnToOctet3(m_base->config->plmn));
 


### PR DESCRIPTION
Proposal of bug fix on gNB-ID field in NGSetupRequest message refers to issue #461.
Actually the gNB-ID Length is not taken into account in gNB-ID field. This field needs to be shifted to MSB.