### PR TITLE
Open5GS changes default MCC/MNC 901/70 -> 999/70

### DIFF
--- a/config/open5gs-gnb.yaml
+++ b/config/open5gs-gnb.yaml
@@ -1,4 +1,4 @@
-mcc: '901'          # Mobile Country Code value
+mcc: '999'          # Mobile Country Code value
 mnc: '70'           # Mobile Network Code value (2 or 3 digits)
 
 nci: '0x000000010'  # NR Cell Identity (36-bit)

--- a/config/open5gs-ue.yaml
+++ b/config/open5gs-ue.yaml
@@ -1,7 +1,7 @@
 # IMSI number of the UE. IMSI = [MCC|MNC|MSISDN] (In total 15 digits)
-supi: 'imsi-901700000000001'
+supi: 'imsi-999700000000001'
 # Mobile Country Code value of HPLMN
-mcc: '901'
+mcc: '999'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '70'
 


### PR DESCRIPTION
Hi @aligungr 

Please note that osmocom USIM changed the default to 999-70 so Open5GS changed it.

Thanks a lot!
Sukchan
