### PR TITLE
Specify minimum required CMake version only once

### DIFF
--- a/src/asn/asn1c/CMakeLists.txt
+++ b/src/asn/asn1c/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB HDR_FILES *.h)
 file(GLOB SRC_FILES *.c)
 

--- a/src/asn/ngap/CMakeLists.txt
+++ b/src/asn/ngap/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB HDR_FILES *.h)
 file(GLOB SRC_FILES *.c)
 

--- a/src/asn/rrc/CMakeLists.txt
+++ b/src/asn/rrc/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB HDR_FILES *.h)
 file(GLOB SRC_FILES *.c)
 

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB_RECURSE H_FILES *.h)
 file(GLOB_RECURSE C_FILES *.c)
 file(GLOB_RECURSE HDR_FILES *.hpp)

--- a/src/gnb/CMakeLists.txt
+++ b/src/gnb/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB_RECURSE HDR_FILES *.hpp)
 file(GLOB_RECURSE SRC_FILES *.cpp)
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB_RECURSE HDR_FILES *.hpp)
 file(GLOB_RECURSE SRC_FILES *.cpp)
 

--- a/src/lib/app/CMakeLists.txt
+++ b/src/lib/app/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB HDR_FILES *.hpp)
 file(GLOB SRC_FILES *.cpp)
 

--- a/src/ue/CMakeLists.txt
+++ b/src/ue/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB_RECURSE HDR_FILES *.hpp)
 file(GLOB_RECURSE SRC_FILES *.cpp)
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
-
 file(GLOB_RECURSE HDR_FILES *.hpp)
 file(GLOB_RECURSE SRC_FILES *.cpp)
 


### PR DESCRIPTION
cmake_minimum_required is only needed in the main CMakeLists.txt