### PR TITLE
Making tunnel interface name configurable

### DIFF
--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -152,6 +152,9 @@ static nr::ue::UeConfig *ReadConfigYaml()
         result->imei = yaml::GetString(config, "imei", 15, 15);
     if (yaml::HasField(config, "imeiSv"))
         result->imeiSv = yaml::GetString(config, "imeiSv", 16, 16);
+    // Interface name has to be 16 bytes long max. Leaving some bytes free for indexing.
+    if (yaml::HasField(config, "tunNamePrefix"))
+        result->tunNamePrefix = yaml::GetString(config, "tunNamePrefix", 1, 13);
 
     yaml::AssertHasField(config, "integrity");
     yaml::AssertHasField(config, "ciphering");
@@ -345,6 +348,7 @@ static nr::ue::UeConfig *GetConfigByUe(int ueIndex)
     c->imei = g_refConfig->imei;
     c->imeiSv = g_refConfig->imeiSv;
     c->supi = g_refConfig->supi;
+    c->tunNamePrefix = g_refConfig->tunNamePrefix;
     c->hplmn = g_refConfig->hplmn;
     c->configuredNssai = g_refConfig->configuredNssai;
     c->defaultConfiguredNssai = g_refConfig->defaultConfiguredNssai;

--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -179,8 +179,10 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
         return;
     }
 
-    std::string error{}, allocatedName{};
-    int fd = tun::TunAllocate(cons::TunNamePrefix, allocatedName, error);
+    std::string error{}, allocatedName{}, requestedName{cons::TunNamePrefix};
+    if (m_base->config->tunNamePrefix.has_value())
+        requestedName = *m_base->config->tunNamePrefix;
+    int fd = tun::TunAllocate(requestedName.c_str(), allocatedName, error);
     if (fd == 0 || error.length() > 0)
     {
         m_logger->err("TUN allocation failure [%s]", error.c_str());

--- a/src/ue/types.hpp
+++ b/src/ue/types.hpp
@@ -106,6 +106,7 @@ struct UeConfig
     IntegrityMaxDataRateConfig integrityMaxRate{};
     NetworkSlice defaultConfiguredNssai{};
     NetworkSlice configuredNssai{};
+    std::optional<std::string> tunNamePrefix{};
 
     struct
     {


### PR DESCRIPTION
Right now, the name of the tunnel interface is `uesimtunX` with X an index increasing with the number of UEs. 
This PR introduces a new field in the UE config to customize the interface name with the `tunNamePrefix` field. 
The name of the interface becomes `prefixX` if the field is present in the configuration. 