### PR TITLE
Adding routing indicator management into the config file.

### DIFF
--- a/config/custom-ue.yaml
+++ b/config/custom-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-286010000000001'
 mcc: '286'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '93'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '465B5CE8B199B49FAA5F0A2EE238A6BC'

--- a/config/free5gc-ue.yaml
+++ b/config/free5gc-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-208930000000003'
 mcc: '208'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '93'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '8baf473f2f8fd09487cccbd7097c6862'

--- a/config/open5gs-ue.yaml
+++ b/config/open5gs-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-999700000000001'
 mcc: '999'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '70'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '465B5CE8B199B49FAA5F0A2EE238A6BC'

--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -109,6 +109,8 @@ static nr::ue::UeConfig *ReadConfigYaml()
     yaml::GetString(config, "mcc", 3, 3);
     result->hplmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
     result->hplmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
+    if (yaml::HasField(config, "routingIndicator"))
+        result->routingIndicator = yaml::GetString(config, "routingIndicator", 4, 4);
 
     for (auto &gnbSearchItem : yaml::GetSequence(config, "gnbSearchList"))
         result->gnbSearchList.push_back(gnbSearchItem.as<std::string>());
@@ -348,6 +350,7 @@ static nr::ue::UeConfig *GetConfigByUe(int ueIndex)
     c->imei = g_refConfig->imei;
     c->imeiSv = g_refConfig->imeiSv;
     c->supi = g_refConfig->supi;
+    c->routingIndicator = g_refConfig->routingIndicator;
     c->tunNamePrefix = g_refConfig->tunNamePrefix;
     c->hplmn = g_refConfig->hplmn;
     c->configuredNssai = g_refConfig->configuredNssai;

--- a/src/ue/nas/mm/identity.cpp
+++ b/src/ue/nas/mm/identity.cpp
@@ -91,7 +91,14 @@ nas::IE5gsMobileIdentity NasMm::generateSuci()
     ret.imsi.plmn.isLongMnc = plmn.isLongMnc;
     ret.imsi.plmn.mcc = plmn.mcc;
     ret.imsi.plmn.mnc = plmn.mnc;
-    ret.imsi.routingIndicator = "0000";
+    if (m_base->config->routingIndicator.has_value())
+    {
+        ret.imsi.routingIndicator = *m_base->config->routingIndicator;
+    }
+    else
+    {
+        ret.imsi.routingIndicator = "0000";
+    }
     ret.imsi.protectionSchemaId = 0;
     ret.imsi.homeNetworkPublicKeyIdentifier = 0;
     ret.imsi.schemeOutput = imsi.substr(plmn.isLongMnc ? 6 : 5);

--- a/src/ue/types.hpp
+++ b/src/ue/types.hpp
@@ -93,6 +93,7 @@ struct UeConfig
 {
     /* Read from config file */
     std::optional<Supi> supi{};
+    std::optional<std::string> routingIndicator{};
     Plmn hplmn{};
     OctetString key{};
     OctetString opC{};


### PR DESCRIPTION
This patch allows to provide Routing Indicator through UE config file. Indeed, RoutingIndicator will be use to select the relevant UDM (unfortunately, it is not always '0000' :o)