### PR TITLE
Adding the Routing Indicator padding as described in the 3GPP TS 24.5…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 **UERANSIM** <small>(pronounced "ju-i ræn sɪm")</small>, is the open-source state-of-the-art 5G UE and RAN (gNodeB)
-implementation. It can be considered as a 5G mobile phone and a base station in basic terms. The project can be used for
+simulator. UE and RAN can be considered as a 5G mobile phone and a base station in basic terms. The project can be used for
 testing 5G Core Network and studying 5G System.
 
 UERANSIM introduces the world's first and only open source 5G-SA UE and gNodeB implementation.
@@ -17,13 +17,10 @@ UERANSIM introduces the world's first and only open source 5G-SA UE and gNodeB i
 
 ## Current Status
 
-Our UE and gNodeB are functional and ready to use. You can connect them to your 5G core network right now and start
-using it.
-
-In terms of 3GPP coverage, fundamental control plane features are done. However, some of them are in progress.
+Basic functionalities of UE and gNodeB are fully functional and ready to use. However some of the features are not complete.
 More details can be found at [Feature Set](https://github.com/aligungr/UERANSIM/wiki/Feature-Set).
 
-Meanwhile, 5G-NR radio interface is partially implemented, and simulated over UDP protocol.
+On the other hand, UERANSIM does not fully provide physical layer. 5G-NR radio interface is partially implemented, and simply simulated over UDP protocol.
 
 <p align="center">
 <img src="https://img.shields.io/badge/Radio%20Interface-simulated-orange" alt="OS Linux"/>
@@ -57,4 +54,4 @@ Copyright (c) 2022 ALİ GÜNGÖR.
 All source code and related files including documentation and wiki pages are
 dual licensed with [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.en.html) and a commercial license.
 
-Commercial usage of UERANSIM is **not** permitted with the GPL-3.0. If you want to use UERANSIM for commercial purposes, please contact [ueransim@gmail.com](mailto:ueransim@gmail.com) to buy a commercial license.
+Commercial usage of UERANSIM is **not** permitted with the GPL-3.0. If GPL-3.0 license is not compatable with your use case, please contact [ueransim@gmail.com](mailto:ueransim@gmail.com) to buy a commercial license.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <img src="https://img.shields.io/badge/License-GPL--3.0-green"/>
 </p>
 
-**UERANSIM** <small>(pronounced "ju-i ræn sɪm")</small>, is the open-source state-of-the-art 5G UE and RAN (gNodeB)
+**UERANSIM** <small>(pronounced "ju-i ræn sɪm")</small>, is the open source state-of-the-art 5G UE and RAN (gNodeB)
 simulator. UE and RAN can be considered as a 5G mobile phone and a base station in basic terms. The project can be used for
 testing 5G Core Network and studying 5G System.
 

--- a/config/custom-ue.yaml
+++ b/config/custom-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-286010000000001'
 mcc: '286'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '93'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '465B5CE8B199B49FAA5F0A2EE238A6BC'

--- a/config/free5gc-ue.yaml
+++ b/config/free5gc-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-208930000000003'
 mcc: '208'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '93'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '8baf473f2f8fd09487cccbd7097c6862'

--- a/config/open5gs-ue.yaml
+++ b/config/open5gs-ue.yaml
@@ -4,6 +4,8 @@ supi: 'imsi-999700000000001'
 mcc: '999'
 # Mobile Network Code value of HPLMN (2 or 3 digits)
 mnc: '70'
+# Routing Indicator
+routingIndicator: '0000'
 
 # Permanent subscription key
 key: '465B5CE8B199B49FAA5F0A2EE238A6BC'

--- a/src/lib/nas/base.cpp
+++ b/src/lib/nas/base.cpp
@@ -10,8 +10,8 @@
 
 #include <stdexcept>
 
-void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
-                          int skippedHalfOctet, bool isRoutingIndicator)
+size_t nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
+                          int skippedHalfOctet)
 {
     size_t requiredHalfOctets = bcd.length();
     if (skipFirst)
@@ -45,35 +45,16 @@ void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t oc
     for (size_t i = 0; i < spare; i++)
         halfOctets[i + bcd.length() + (skipFirst ? 1 : 0)] = 0xF;
 
-    size_t octectCount = 0;
+    size_t octetCount = 0;
     for (size_t i = 0; i < requiredHalfOctets / 2; i++)
     {
         int little = halfOctets[2 * i];
         int big = halfOctets[2 * i + 1];
         int octet = big << 4 | little;
         stream.appendOctet(octet);
-        octectCount++;
+        octetCount++;
     }
-    // 3GPP TS 24.501 section 9.11.3.4 (mobile identity) table 9.11.3.4.1
-    // Routing Indicator shall consist of 1 to 4 digits. The coding of this
-    // field is the responsibility of home network operator but BCD coding 
-    // shall be used. If a network operator decides to assign less than 
-    // 4 digits to Routing Indicator, the remaining digits shall be coded 
-    // as "1111" to fill the 4 digits coding of Routing Indicator 
-    // (see NOTE 2). If no Routing Indicator is configured in the USIM, the
-    // UE shall code bits 1 to 4 of octet 8 of the Routing Indicator 
-    // as "0000" and the remaining digits as “1111".
-    //
-    // NOTE 2:	For a 3-digit Routing Indicator, e.g "567", bits 1 to 4 of
-    // octet 8 are coded as "0101", bits 5 to 8 of octet 8 are coded as
-    // "0110", bits 1 to 4 of octet 9 are coded as "0111", bits 5 to 8 of
-    // octet 9 are coded as "1111".
-    if (isRoutingIndicator) {
-        while (octectCount < octetLength) {
-            stream.appendOctet(0xFF);
-            octectCount++;
-        }
-    }    
+    return octetCount;
 }
 
 std::string nas::DecodeBcdString(const OctetView &stream, int length, bool skipFirst)
@@ -109,4 +90,15 @@ std::string nas::DecodeBcdString(const OctetView &stream, int length, bool skipF
     }
 
     return str;
+}
+
+
+void nas::EncodeRoutingIndicator(OctetString &stream, const std::string &bcd)
+{
+    size_t count;
+    count = EncodeBcdString(stream, bcd, 2, false, 0);
+
+    if (count < 2) {
+        stream.appendOctet(0xFF);
+    }
 }

--- a/src/lib/nas/base.cpp
+++ b/src/lib/nas/base.cpp
@@ -11,7 +11,7 @@
 #include <stdexcept>
 
 void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
-                          int skippedHalfOctet)
+                          int skippedHalfOctet, bool isRoutingIndicator)
 {
     size_t requiredHalfOctets = bcd.length();
     if (skipFirst)
@@ -45,13 +45,35 @@ void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t oc
     for (size_t i = 0; i < spare; i++)
         halfOctets[i + bcd.length() + (skipFirst ? 1 : 0)] = 0xF;
 
+    size_t octectCount = 0;
     for (size_t i = 0; i < requiredHalfOctets / 2; i++)
     {
         int little = halfOctets[2 * i];
         int big = halfOctets[2 * i + 1];
         int octet = big << 4 | little;
         stream.appendOctet(octet);
+        octectCount++;
     }
+    // 3GPP TS 24.501 section 9.11.3.4 (mobile identity) table 9.11.3.4.1
+    // Routing Indicator shall consist of 1 to 4 digits. The coding of this
+    // field is the responsibility of home network operator but BCD coding 
+    // shall be used. If a network operator decides to assign less than 
+    // 4 digits to Routing Indicator, the remaining digits shall be coded 
+    // as "1111" to fill the 4 digits coding of Routing Indicator 
+    // (see NOTE 2). If no Routing Indicator is configured in the USIM, the
+    // UE shall code bits 1 to 4 of octet 8 of the Routing Indicator 
+    // as "0000" and the remaining digits as “1111".
+    //
+    // NOTE 2:	For a 3-digit Routing Indicator, e.g "567", bits 1 to 4 of
+    // octet 8 are coded as "0101", bits 5 to 8 of octet 8 are coded as
+    // "0110", bits 1 to 4 of octet 9 are coded as "0111", bits 5 to 8 of
+    // octet 9 are coded as "1111".
+    if (isRoutingIndicator) {
+        while (octectCount < octetLength) {
+            stream.appendOctet(0xFF);
+            octectCount++;
+        }
+    }    
 }
 
 std::string nas::DecodeBcdString(const OctetView &stream, int length, bool skipFirst)

--- a/src/lib/nas/base.hpp
+++ b/src/lib/nas/base.hpp
@@ -239,7 +239,7 @@ static inline bool DecodeListVal(const OctetView &stream, int length, std::vecto
 }
 
 void EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
-                     int skippedHalfOctet);
+                     int skippedHalfOctet, bool isRoutingIndicator = false);
 
 std::string DecodeBcdString(const OctetView &stream, int length, bool skipFirst);
 

--- a/src/lib/nas/base.hpp
+++ b/src/lib/nas/base.hpp
@@ -238,9 +238,11 @@ static inline bool DecodeListVal(const OctetView &stream, int length, std::vecto
     return true;
 }
 
-void EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
-                     int skippedHalfOctet, bool isRoutingIndicator = false);
+size_t EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
+                     int skippedHalfOctet);
 
 std::string DecodeBcdString(const OctetView &stream, int length, bool skipFirst);
+
+void EncodeRoutingIndicator(OctetString &stream, const std::string &bcd);
 
 } // namespace nas

--- a/src/lib/nas/ie6.cpp
+++ b/src/lib/nas/ie6.cpp
@@ -304,7 +304,7 @@ void IE5gsMobileIdentity::Encode(const IE5gsMobileIdentity &ie, OctetString &str
 
             VPlmn::Encode(VPlmn{ie.imsi.plmn.mcc, ie.imsi.plmn.mnc, ie.imsi.plmn.isLongMnc}, stream);
 
-            EncodeBcdString(stream, ie.imsi.routingIndicator, 2, false, 0, true);
+            EncodeRoutingIndicator(stream, ie.imsi.routingIndicator);
             stream.appendOctet(ie.imsi.protectionSchemaId);
             stream.appendOctet(ie.imsi.homeNetworkPublicKeyIdentifier);
 

--- a/src/lib/nas/ie6.cpp
+++ b/src/lib/nas/ie6.cpp
@@ -304,7 +304,7 @@ void IE5gsMobileIdentity::Encode(const IE5gsMobileIdentity &ie, OctetString &str
 
             VPlmn::Encode(VPlmn{ie.imsi.plmn.mcc, ie.imsi.plmn.mnc, ie.imsi.plmn.isLongMnc}, stream);
 
-            EncodeBcdString(stream, ie.imsi.routingIndicator, 2, false, 0);
+            EncodeBcdString(stream, ie.imsi.routingIndicator, 2, false, 0, true);
             stream.appendOctet(ie.imsi.protectionSchemaId);
             stream.appendOctet(ie.imsi.homeNetworkPublicKeyIdentifier);
 

--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -110,7 +110,7 @@ static nr::ue::UeConfig *ReadConfigYaml()
     result->hplmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
     result->hplmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
     if (yaml::HasField(config, "routingIndicator"))
-        result->routingIndicator = yaml::GetString(config, "routingIndicator", 4, 4);
+        result->routingIndicator = yaml::GetString(config, "routingIndicator", 1, 4);
 
     for (auto &gnbSearchItem : yaml::GetSequence(config, "gnbSearchList"))
         result->gnbSearchList.push_back(gnbSearchItem.as<std::string>());

--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -109,6 +109,8 @@ static nr::ue::UeConfig *ReadConfigYaml()
     yaml::GetString(config, "mcc", 3, 3);
     result->hplmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
     result->hplmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
+    if (yaml::HasField(config, "routingIndicator"))
+        result->routingIndicator = yaml::GetString(config, "routingIndicator", 4, 4);
 
     for (auto &gnbSearchItem : yaml::GetSequence(config, "gnbSearchList"))
         result->gnbSearchList.push_back(gnbSearchItem.as<std::string>());
@@ -348,6 +350,7 @@ static nr::ue::UeConfig *GetConfigByUe(int ueIndex)
     c->imei = g_refConfig->imei;
     c->imeiSv = g_refConfig->imeiSv;
     c->supi = g_refConfig->supi;
+    c->routingIndicator = g_refConfig->routingIndicator;
     c->tunNamePrefix = g_refConfig->tunNamePrefix;
     c->hplmn = g_refConfig->hplmn;
     c->configuredNssai = g_refConfig->configuredNssai;

--- a/src/ue/nas/mm/identity.cpp
+++ b/src/ue/nas/mm/identity.cpp
@@ -91,7 +91,14 @@ nas::IE5gsMobileIdentity NasMm::generateSuci()
     ret.imsi.plmn.isLongMnc = plmn.isLongMnc;
     ret.imsi.plmn.mcc = plmn.mcc;
     ret.imsi.plmn.mnc = plmn.mnc;
-    ret.imsi.routingIndicator = "0000";
+    if (m_base->config->routingIndicator.has_value())
+    {
+        ret.imsi.routingIndicator = *m_base->config->routingIndicator;
+    }
+    else
+    {
+        ret.imsi.routingIndicator = "0000";
+    }
     ret.imsi.protectionSchemaId = 0;
     ret.imsi.homeNetworkPublicKeyIdentifier = 0;
     ret.imsi.schemeOutput = imsi.substr(plmn.isLongMnc ? 6 : 5);

--- a/src/ue/types.hpp
+++ b/src/ue/types.hpp
@@ -93,6 +93,7 @@ struct UeConfig
 {
     /* Read from config file */
     std::optional<Supi> supi{};
+    std::optional<std::string> routingIndicator{};
     Plmn hplmn{};
     OctetString key{};
     OctetString opC{};


### PR DESCRIPTION
When the Routing Indicator is less than 4 digits, the value needs to be completed according to the table 9.11.3.4.1 in section 9.11.3.4 from the document 3GPP TS 24.501.

This patch proposes  a quick adaptation of encodeBCD.