### PR TITLE
Adding EncodeRoutingIndicator with slightly modified EncodeBcdString

### DIFF
--- a/src/lib/nas/base.cpp
+++ b/src/lib/nas/base.cpp
@@ -10,7 +10,7 @@
 
 #include <stdexcept>
 
-void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
+size_t nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
                           int skippedHalfOctet)
 {
     size_t requiredHalfOctets = bcd.length();
@@ -45,13 +45,16 @@ void nas::EncodeBcdString(OctetString &stream, const std::string &bcd, size_t oc
     for (size_t i = 0; i < spare; i++)
         halfOctets[i + bcd.length() + (skipFirst ? 1 : 0)] = 0xF;
 
+    size_t octetCount = 0;
     for (size_t i = 0; i < requiredHalfOctets / 2; i++)
     {
         int little = halfOctets[2 * i];
         int big = halfOctets[2 * i + 1];
         int octet = big << 4 | little;
         stream.appendOctet(octet);
+        octetCount++;
     }
+    return octetCount;
 }
 
 std::string nas::DecodeBcdString(const OctetView &stream, int length, bool skipFirst)
@@ -87,4 +90,15 @@ std::string nas::DecodeBcdString(const OctetView &stream, int length, bool skipF
     }
 
     return str;
+}
+
+
+void nas::EncodeRoutingIndicator(OctetString &stream, const std::string &bcd)
+{
+    size_t count;
+    count = EncodeBcdString(stream, bcd, 2, false, 0);
+
+    if (count < 2) {
+        stream.appendOctet(0xFF);
+    }
 }

--- a/src/lib/nas/base.hpp
+++ b/src/lib/nas/base.hpp
@@ -238,9 +238,11 @@ static inline bool DecodeListVal(const OctetView &stream, int length, std::vecto
     return true;
 }
 
-void EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
+size_t EncodeBcdString(OctetString &stream, const std::string &bcd, size_t octetLength, bool skipFirst,
                      int skippedHalfOctet);
 
 std::string DecodeBcdString(const OctetView &stream, int length, bool skipFirst);
+
+void EncodeRoutingIndicator(OctetString &stream, const std::string &bcd);
 
 } // namespace nas

--- a/src/lib/nas/ie6.cpp
+++ b/src/lib/nas/ie6.cpp
@@ -304,7 +304,7 @@ void IE5gsMobileIdentity::Encode(const IE5gsMobileIdentity &ie, OctetString &str
 
             VPlmn::Encode(VPlmn{ie.imsi.plmn.mcc, ie.imsi.plmn.mnc, ie.imsi.plmn.isLongMnc}, stream);
 
-            EncodeBcdString(stream, ie.imsi.routingIndicator, 2, false, 0);
+            EncodeRoutingIndicator(stream, ie.imsi.routingIndicator);
             stream.appendOctet(ie.imsi.protectionSchemaId);
             stream.appendOctet(ie.imsi.homeNetworkPublicKeyIdentifier);
 

--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -110,7 +110,7 @@ static nr::ue::UeConfig *ReadConfigYaml()
     result->hplmn.mnc = yaml::GetInt32(config, "mnc", 0, 999);
     result->hplmn.isLongMnc = yaml::GetString(config, "mnc", 2, 3).size() == 3;
     if (yaml::HasField(config, "routingIndicator"))
-        result->routingIndicator = yaml::GetString(config, "routingIndicator", 4, 4);
+        result->routingIndicator = yaml::GetString(config, "routingIndicator", 1, 4);
 
     for (auto &gnbSearchItem : yaml::GetSequence(config, "gnbSearchList"))
         result->gnbSearchList.push_back(gnbSearchItem.as<std::string>());


### PR DESCRIPTION
As exchanged, please find a new short function EncodeRoutingIndicator using a modified version of EncodeBcdString. This last one now return size_t instead of void.

Note that if you prefer, the 2 functions could be completly separated. However, the base code would remain the same. That's explaining my approach of modification....