### PR TITLE
Fix incomplete and undeclared symbols

### DIFF
--- a/src/lib/rlc/test.cpp
+++ b/src/lib/rlc/test.cpp
@@ -9,6 +9,9 @@
 #include "test.hpp"
 #include "rlc.hpp"
 
+#include <string>
+#include <cstdio>
+
 #include <utils/nts.hpp>
 
 enum class EntityType

--- a/src/lib/sctp/server.hpp
+++ b/src/lib/sctp/server.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace sctp
 {

--- a/src/utils/logger.hpp
+++ b/src/utils/logger.hpp
@@ -11,6 +11,7 @@
 #include "nts.hpp"
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <spdlog/fwd.h>


### PR DESCRIPTION
While the code may compile already for some people, different compilers and versions of the STL may fail to compile the code if the STL's includes change.

This commit fixes errors preventing compilation on Arch with GCC 13.2.1.

The includes added by this commit prevent the following compilation errors:

```
In file included from /home/chaton/Downloads/UERANSIM/src/utils/logger.cpp:9:
/home/chaton/Downloads/UERANSIM/src/utils/logger.hpp: In member function ‘void Logger::debug(const std::string&)’:
/home/chaton/Downloads/UERANSIM/src/utils/logger.hpp:48:36: error: invalid use of incomplete type ‘const std::string’ {aka ‘const class std::__cxx11::basic_string<char>’}
   48 |         log(Severity::DEBUG, "%s", fmt.c_str());
      |                                    ^~~
In file included from /usr/include/c++/13.2.1/iosfwd:41,
                 from /usr/include/c++/13.2.1/bits/shared_ptr.h:52,
                 from /usr/include/c++/13.2.1/condition_variable:45,
                 from /home/chaton/Downloads/UERANSIM/src/utils/nts.hpp:15,
                 from /home/chaton/Downloads/UERANSIM/src/utils/logger.hpp:11:
/usr/include/c++/13.2.1/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   72 |     class basic_string;
      |           ^~~~~~~~~~~~
/home/chaton/Downloads/UERANSIM/src/utils/logger.hpp: In member function ‘void Logger::info(const std::string&)’:
/home/chaton/Downloads/UERANSIM/src/utils/logger.hpp:59:35: error: invalid use of incomplete type ‘const std::string’ {aka ‘const class std::__cxx11::basic_string<char>’}
   59 |         log(Severity::INFO, "%s", fmt.c_str());
      |                                   ^~~
```

```
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:64:17: error: field ‘tag’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
   64 |     std::string tag;
      |                 ^~~
In file included from /usr/include/c++/13.2.1/iosfwd:41,
                 from /usr/include/c++/13.2.1/bits/shared_ptr.h:52,
                 from /usr/include/c++/13.2.1/condition_variable:45,
                 from /home/chaton/Downloads/UERANSIM/src/utils/nts.hpp:15,
                 from /home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:12:
/usr/include/c++/13.2.1/bits/stringfwd.h:72:11: note: declaration of ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’}
   72 |     class basic_string;
      |           ^~~~~~~~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp: In member function ‘void rlc::RlcTask::upperTransmission()’:
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:133:13: error: ‘puts’ was not declared in this scope
  133 |             puts("ENOUGH TESTING TODAY");
      |             ^~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp: In member function ‘virtual void rlc::RlcTask::deliverSdu(rlc::IRlcEntity*, uint8_t*, int)’:
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:147:9: error: ‘printf’ was not declared in this scope
  147 |         printf("[%s] PDU RECEIVED, TOTAL COUNT %d B\n", tag.c_str(), receivedCounter * TRANSMISSION_SIZE);
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:13:1: note: ‘printf’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
   12 | #include <utils/nts.hpp>
  +++ |+#include <cstdio>
   13 | 
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:154:16: error: ‘stdout’ was not declared in this scope
  154 |         fflush(stdout);
      |                ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:154:16: note: ‘stdout’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:154:9: error: ‘fflush’ was not declared in this scope
  154 |         fflush(stdout);
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp: In member function ‘virtual void rlc::RlcTask::maxRetransmissionReached(rlc::IRlcEntity*)’:
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:159:9: error: ‘printf’ was not declared in this scope
  159 |         printf("[%s] RADIO LINK FAILURE\n", tag.c_str());
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:159:9: note: ‘printf’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:160:16: error: ‘stdout’ was not declared in this scope
  160 |         fflush(stdout);
      |                ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:160:16: note: ‘stdout’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:160:9: error: ‘fflush’ was not declared in this scope
  160 |         fflush(stdout);
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp: In member function ‘virtual void rlc::RlcTask::sduSuccessfulDelivery(rlc::IRlcEntity*, int)’:
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:165:9: error: ‘printf’ was not declared in this scope
  165 |         printf("[%s] SDU %d DELIVERED\n", tag.c_str(), sduId);
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:165:9: note: ‘printf’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:166:16: error: ‘stdout’ was not declared in this scope
  166 |         fflush(stdout);
      |                ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:166:16: note: ‘stdout’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:166:9: error: ‘fflush’ was not declared in this scope
  166 |         fflush(stdout);
      |         ^~~~~~
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp: In function ‘void rlc::rlcTestMain()’:
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:181:5: error: ‘printf’ was not declared in this scope
  181 |     printf("%ld\n", currentTimeMs());
```

```
/home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:64:17: error: field ‘tag’ has incomplete type ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’}
   64 |     std::string tag;
      |                 ^~~
In file included from /usr/include/c++/13.2.1/iosfwd:41,
                 from /usr/include/c++/13.2.1/bits/shared_ptr.h:52,
                 from /usr/include/c++/13.2.1/condition_variable:45,
                 from /home/chaton/Downloads/UERANSIM/src/utils/nts.hpp:15,
                 from /home/chaton/Downloads/UERANSIM/src/lib/rlc/test.cpp:12:
```