### PR TITLE
Fix ipv6-only sctp socket family issue

### DIFF
--- a/src/gnb/sctp/task.cpp
+++ b/src/gnb/sctp/task.cpp
@@ -195,7 +195,7 @@ void SctpTask::receiveSctpConnectionSetupRequest(int clientId, const std::string
 {
     m_logger->info("Trying to establish SCTP connection... (%s:%d)", remoteAddress.c_str(), remotePort);
 
-    auto *client = new sctp::SctpClient(ppid);
+    auto *client = new sctp::SctpClient(ppid, localAddress);
 
     try
     {

--- a/src/lib/sctp/client.cpp
+++ b/src/lib/sctp/client.cpp
@@ -9,10 +9,11 @@
 #include "client.hpp"
 #include "internal.hpp"
 
-sctp::SctpClient::SctpClient(PayloadProtocolId ppid) : sd(CreateSocket()), ppid(ppid)
+sctp::SctpClient::SctpClient(PayloadProtocolId ppid, const std::string &address) : sd(0), ppid(ppid)
 {
     try
     {
+        sd = CreateSocket(address);
         SetInitOptions(sd, 10, 10, 10, 10 * 1000);
         SetEventOptions(sd);
     }

--- a/src/lib/sctp/client.hpp
+++ b/src/lib/sctp/client.hpp
@@ -19,11 +19,11 @@ namespace sctp
 class SctpClient
 {
   private:
-    const int sd;
+    int sd;
     const PayloadProtocolId ppid;
 
   public:
-    explicit SctpClient(PayloadProtocolId ppid);
+    explicit SctpClient(PayloadProtocolId ppid, const std::string &address);
     ~SctpClient();
 
     void bind(const std::string &address, uint16_t port);

--- a/src/lib/sctp/internal.cpp
+++ b/src/lib/sctp/internal.cpp
@@ -38,9 +38,14 @@ namespace sctp
     throw SctpError(prefix + str);
 }
 
-int CreateSocket()
+int CreateSocket(const std::string &address)
 {
-    int sd = socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP);
+    int sd = 0;
+    int ipVersion = utils::GetIpVersion(address);
+    if (ipVersion == 6)
+        sd = socket(AF_INET6, SOCK_STREAM, IPPROTO_SCTP);
+    else
+        sd = socket(AF_INET, SOCK_STREAM, IPPROTO_SCTP);
     if (sd < 0)
         ThrowError("SCTP socket could not be created");
     return sd;

--- a/src/lib/sctp/internal.hpp
+++ b/src/lib/sctp/internal.hpp
@@ -15,7 +15,7 @@
 namespace sctp
 {
 
-int CreateSocket();
+int CreateSocket(const std::string &address);
 void BindSocket(int sd, const std::string &address, uint16_t port);
 void SetInitOptions(int sd, int maxRxStreams, int maxTxStreams, int maxAttempts, int initTimeoutMs);
 void SetEventOptions(int sd);

--- a/src/lib/sctp/server.cpp
+++ b/src/lib/sctp/server.cpp
@@ -13,7 +13,7 @@ sctp::SctpServer::SctpServer(const std::string &address, uint16_t port) : sd(0)
 {
     try
     {
-        sd = CreateSocket();
+        sd = CreateSocket(address);
         BindSocket(sd, address, port);
         SetInitOptions(sd, 10, 10, 10, 10 * 1000);
         SetEventOptions(sd);


### PR DESCRIPTION
Hello @aligungr 

This will enable UERANSIM to create an SCTP socket even if IPv6 is disabled on the target machine.
This was taken into account in the server code, but not in the client's.

Thanks