### PR TITLE
various eap-aka-prime fixes

### DIFF
--- a/src/lib/nas/eap.hpp
+++ b/src/lib/nas/eap.hpp
@@ -135,6 +135,7 @@ enum class EEapType
 class EapAttributes
 {
     std::array<std::optional<OctetString>, 256> attributes{};
+    std::vector<int> order_received{};
 
   public:
     [[nodiscard]] OctetString getRand() const;
@@ -147,12 +148,14 @@ class EapAttributes
   public:
     void putRes(const OctetString &value);
     void putMac(const OctetString &value);
+    void replaceMac(const OctetString &value);
     void putKdf(int value);
     void putClientErrorCode(int code);
     void putAuts(OctetString &&auts);
 
   public:
     void forEachEntry(const std::function<void(EAttributeType, const OctetString &)> &fun) const;
+    void forEachEntryOrdered(const std::function<void(EAttributeType, const OctetString &)> &fun) const;
     void putRawAttribute(EAttributeType key, OctetString &&value);
 };
 

--- a/src/ue/nas/keys.cpp
+++ b/src/ue/nas/keys.cpp
@@ -91,7 +91,7 @@ std::pair<OctetString, OctetString> CalculateCkPrimeIkPrime(const OctetString &c
 OctetString CalculateMk(const OctetString &ckPrime, const OctetString &ikPrime, const Supi &supiIdentity)
 {
     OctetString key = OctetString::Concat(ikPrime, ckPrime);
-    OctetString input = OctetString::FromAscii("EAP-AKA'" + supiIdentity.type + "-" + supiIdentity.value);
+    OctetString input = OctetString::FromAscii("EAP-AKA'" + supiIdentity.value);
 
     // Calculating the 208-octet output
     return crypto::CalculatePrfPrime(key, input, 208);
@@ -103,11 +103,11 @@ OctetString CalculateMacForEapAkaPrime(const OctetString &kaut, const eap::EapAk
     eap::EapAkaPrime copy{message.code, message.id, message.subType};
 
     // Deep copy each attribute
-    message.attributes.forEachEntry(
+    message.attributes.forEachEntryOrdered(
         [&copy](eap::EAttributeType attr, const OctetString &v) { copy.attributes.putRawAttribute(attr, v.copy()); });
 
     // Except the MAC field
-    copy.attributes.putMac(OctetString::FromSpare(16));
+    copy.attributes.replaceMac(OctetString::FromSpare(16));
 
     OctetString input{};
     eap::EncodeEapPdu(input, copy);


### PR DESCRIPTION
* remove spurious length check when fetching attributes, such as in getRand(), getMac() etc.
* fix the AT_RES length (it's in bits, not bytes)
* fix reordering of attributes and MAC computation issues
* fix SUPI input to the master key (remove the supi type prefix)
* use kAusf computation for eap-aka' rather than the 5g-aka one

Inspired in large part by the issues and solutions reported in #592