### PR TITLE
Encode DNN as Labels

### DIFF
--- a/src/lib/nas/utils.cpp
+++ b/src/lib/nas/utils.cpp
@@ -273,9 +273,24 @@ const char *EnumToString(EPduSessionType v)
 IEDnn DnnFromApn(const std::string &apn)
 {
     IEDnn dnn;
+    int index = 0;
     dnn.apn = OctetString::FromSpare(static_cast<int>(apn.length()) + 1);
-    dnn.apn.data()[0] = static_cast<uint8_t>(apn.length());
-    std::memcpy(dnn.apn.data() + 1, apn.data(), apn.length());
+    std::stringstream ss(apn);
+
+    std::string token;
+    std::vector<std::string> tokens;
+    char delimiter = '.';
+
+    while (getline(ss, token, delimiter)) {
+        tokens.push_back(token);
+    }
+
+    for (const auto& part : tokens) {
+        std::cout << part;
+        dnn.apn.data()[index] = static_cast<uint8_t>(part.length());
+        std::memcpy(dnn.apn.data() + index + 1, part.c_str(), part.length());
+        index = index + part.length() + 1;
+    }
     return dnn;
 }
 


### PR DESCRIPTION
According to TS24.501 9.11.2.1B, _A DNN value field contains an APN as defined in 3GPP TS 23.003_.  Section 9.1.  The APN consists of one or more labels. Each label is coded as a one octet length field followed by that number of octets coded as 8 bit ASCII characters.

This change will properly account for that, and allow for the use of an APN configured with dots, where the dots in the configuration will be split into the proper labels.