### PR TITLE
Add check for empty NAS PDU

### DIFF
--- a/src/ue/nas/mm/sap.cpp
+++ b/src/ue/nas/mm/sap.cpp
@@ -25,6 +25,11 @@ void NasMm::handleRrcEvent(const NmUeRrcToNas &msg)
         break;
     }
     case NmUeRrcToNas::NAS_DELIVERY: {
+        if (msg.nasPdu.length() == 0)
+        {
+            m_logger->err("Empty NAS PDU received, ignore it");
+            break;
+        }
         OctetView buffer{msg.nasPdu};
         auto nasMessage = nas::DecodeNasMessage(buffer);
         if (nasMessage != nullptr)


### PR DESCRIPTION
When I try to use UERANSIM with some poorly implemented Cores, it returns an empty NAS PDU which causes a crash in the UE. The additional PDU length check should fix the crash. 