### PR TITLE
sysInfo: Check BarringInfoList presence before unpacking

### DIFF
--- a/src/ue/rrc/sysinfo.cpp
+++ b/src/ue/rrc/sysinfo.cpp
@@ -51,16 +51,21 @@ void UeRrcTask::receiveSib1(int cellId, const ASN_RRC_SIB1 &msg)
     auto plmnIdentity = plmnIdentityInfo->plmn_IdentityList.list.array[0];
     desc.sib1.plmn = asn::rrc::GetPlmnId(*plmnIdentity);
 
-    auto *barringInfo = msg.uac_BarringInfo->uac_BarringInfoSetList.list.array[0];
 
-    int barringBits = asn::GetBitStringInt<7>(barringInfo->uac_BarringForAccessIdentity);
-    desc.sib1.aiBarringSet.ai15 = bits::BitAt<0>(barringBits);
-    desc.sib1.aiBarringSet.ai14 = bits::BitAt<1>(barringBits);
-    desc.sib1.aiBarringSet.ai13 = bits::BitAt<2>(barringBits);
-    desc.sib1.aiBarringSet.ai12 = bits::BitAt<3>(barringBits);
-    desc.sib1.aiBarringSet.ai11 = bits::BitAt<4>(barringBits);
-    desc.sib1.aiBarringSet.ai2 = bits::BitAt<5>(barringBits);
-    desc.sib1.aiBarringSet.ai1 = bits::BitAt<6>(barringBits);
+    // The UAC_BarringInfoSetList is optional
+    // C.f.: https://www.nrexplained.com/rrc/ge0#SIB1
+    if(msg.uac_BarringInfo){
+        auto *barringInfo = msg.uac_BarringInfo->uac_BarringInfoSetList.list.array[0];
+
+        int barringBits = asn::GetBitStringInt<7>(barringInfo->uac_BarringForAccessIdentity);
+        desc.sib1.aiBarringSet.ai15 = bits::BitAt<0>(barringBits);
+        desc.sib1.aiBarringSet.ai14 = bits::BitAt<1>(barringBits);
+        desc.sib1.aiBarringSet.ai13 = bits::BitAt<2>(barringBits);
+        desc.sib1.aiBarringSet.ai12 = bits::BitAt<3>(barringBits);
+        desc.sib1.aiBarringSet.ai11 = bits::BitAt<4>(barringBits);
+        desc.sib1.aiBarringSet.ai2 = bits::BitAt<5>(barringBits);
+        desc.sib1.aiBarringSet.ai1 = bits::BitAt<6>(barringBits);
+    }
 
     desc.sib1.hasSib1 = true;
 


### PR DESCRIPTION
Otherwise, the UE crashes with a NULL Derference. This patch should introduce the check before accessing the barring bits. 

From the specification 3GPP TS 38.331 the uac-BarringInfo is defined as optional: 

```
uac-BarringInfo SEQUENCE {
      uac-BarringForCommon [UAC-BarringPerCatList] OPTIONAL, -- Need S
      uac-BarringPerPLMN-List [UAC-BarringPerPLMN-List] OPTIONAL, -- Need S
      uac-BarringInfoSetList [UAC-BarringInfoSetList],
      uac-AccessCategory1-SelectionAssistanceInfo CHOICE {
         plmnCommon [UAC-AccessCategory1-SelectionAssistanceInfo],
         individualPLMNList SEQUENCE (SIZE (2..[maxPLMN]) OF [UAC-AccessCategory1-SelectionAssistanceInfo]
         } OPTIONAL-- Need S
      } OPTIONAL, -- Need R
```

Cheers,
Eduard