### PR TITLE
Eap: Fix check for invaild message hadling

### DIFF
--- a/src/lib/nas/eap.cpp
+++ b/src/lib/nas/eap.cpp
@@ -222,9 +222,16 @@ std::unique_ptr<eap::Eap> eap::DecodeEapPdu(const OctetView &stream)
             auto t = static_cast<EAttributeType>(stream.readI());
             readBytes += 1;
 
+            if (t < EAttributeType::AT_RAND || t > EAttributeType::AT_TRUST_IND)
+                return nullptr;
+
             // decode attribute length
             auto attributeLength = stream.readI();
             readBytes += 1;
+
+            // Valid length must be at least 2 octets
+            if (attributeLength < 2)
+                return nullptr;
 
             // decode attribute value
             auto attributeVal = stream.readOctetString(4 * attributeLength - 2);

--- a/src/lib/nas/eap.cpp
+++ b/src/lib/nas/eap.cpp
@@ -189,6 +189,10 @@ void eap::EncodeEapPdu(OctetString &stream, const eap::Eap &pdu)
 std::unique_ptr<eap::Eap> eap::DecodeEapPdu(const OctetView &stream)
 {
     auto code = static_cast<ECode>(stream.readI());
+
+    if (code < ECode::REQUEST || code > ECode::FINISH)
+        return nullptr;
+
     int id = stream.readI();
     int length = stream.read2I();
 
@@ -196,6 +200,9 @@ std::unique_ptr<eap::Eap> eap::DecodeEapPdu(const OctetView &stream)
         return std::make_unique<Eap>(code, id, EEapType::NO_TYPE);
 
     auto type = static_cast<EEapType>(stream.readI());
+
+    if (type < EEapType::NO_TYPE || type > EEapType::EXPERIMENTAL)
+        return nullptr;
 
     int innerLength = length - 1 // code
                       - 1        // id
@@ -208,6 +215,10 @@ std::unique_ptr<eap::Eap> eap::DecodeEapPdu(const OctetView &stream)
 
         // decode subtype
         auto subType = static_cast<ESubType>(stream.readI());
+
+        if (subType < ESubType::AKA_CHALLENGE || subType > ESubType::AKA_CLIENT_ERROR)
+            return nullptr;
+
         readBytes += 1;
 
         auto *akaPrime = new EapAkaPrime(code, id, subType);

--- a/src/ue/nas/mm/auth.cpp
+++ b/src/ue/nas/mm/auth.cpp
@@ -70,7 +70,7 @@ void NasMm::receiveAuthenticationRequestEap(const nas::AuthenticationRequest &ms
 
     // ========================== Check the received message syntactically ==========================
 
-    if (!msg.eapMessage.has_value())
+    if (!msg.eapMessage.has_value() || !msg.eapMessage->eap)
     {
         sendMmStatus(nas::EMmCause::SEMANTICALLY_INCORRECT_MESSAGE);
         return;
@@ -426,7 +426,7 @@ void NasMm::receiveAuthenticationReject(const nas::AuthenticationReject &msg)
     m_usim->m_resStar = {};
     m_timers->t3516.stop();
 
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::FAILURE)
             receiveEapFailureMessage(*msg.eapMessage->eap);

--- a/src/ue/nas/mm/register.cpp
+++ b/src/ue/nas/mm/register.cpp
@@ -610,7 +610,7 @@ void NasMm::receiveInitialRegistrationReject(const nas::RegistrationReject &msg)
     auto cause = msg.mmCause.value;
     auto regType = m_lastRegistrationRequest->registrationType.registrationType;
 
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::FAILURE)
             receiveEapFailureMessage(*msg.eapMessage->eap);
@@ -768,7 +768,7 @@ void NasMm::receiveMobilityRegistrationReject(const nas::RegistrationReject &msg
     auto cause = msg.mmCause.value;
     auto regType = m_lastRegistrationRequest->registrationType.registrationType;
 
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::FAILURE)
             receiveEapFailureMessage(*msg.eapMessage->eap);

--- a/src/ue/nas/mm/security.cpp
+++ b/src/ue/nas/mm/security.cpp
@@ -227,7 +227,7 @@ void NasMm::receiveSecurityModeCommand(const nas::SecurityModeCommand &msg)
 
     // ============================ Handle EAP-Success message if any. ============================
 
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::SUCCESS)
             receiveEapSuccessMessage(*msg.eapMessage->eap);

--- a/src/ue/nas/mm/service.cpp
+++ b/src/ue/nas/mm/service.cpp
@@ -255,7 +255,7 @@ void NasMm::receiveServiceAccept(const nas::ServiceAccept &msg)
     }
 
     // Handle EAP message
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::FAILURE)
             receiveEapFailureMessage(*msg.eapMessage->eap);
@@ -307,7 +307,7 @@ void NasMm::receiveServiceReject(const nas::ServiceReject &msg)
     }
 
     // Handle EAP message
-    if (msg.eapMessage.has_value())
+    if (msg.eapMessage.has_value() && msg.eapMessage->eap)
     {
         if (msg.eapMessage->eap->code == eap::ECode::FAILURE)
             receiveEapFailureMessage(*msg.eapMessage->eap);


### PR DESCRIPTION
Hello :)

We want to submit some patches that target the EAP message parsing and the handling for authentication. There are three issues that we identified and fixed in this series:

1. An invalid message type (which leads to a`nullptr` is not handled correctly for the authentication functions (e.g. `NasMm::receiveAuthenticationRequestEap`), since the IE might evalute to `nullptr` although the message is not valid. This leads to segmentation faults during execution.

2. An EAP message with invalid length fields (a length < 2 for attributes) leads to an unbounded read in `readOctetString`, since the `last` bound is smaller then the `first` bound. 

3. They `enum` type bounds for EAP `structs` are not checked upon parsing, although they provide an early information on processing. This is relevant for parsing the concrete EAPAttributes.

We are happy to provide concrete pcap traces if necessary.

Cheers 