### PR TITLE
feat:signal_UE_deregistration_to_5G_Core

### DIFF
--- a/src/gnb/ngap/task.hpp
+++ b/src/gnb/ngap/task.hpp
@@ -61,6 +61,7 @@ class NgapTask : public NtsTask
   public:
     explicit NgapTask(TaskBase *base);
     ~NgapTask() override = default;
+    void sendContextRelease(int ueId, NgapCause cause);
 
   protected:
     void onStart() override;
@@ -115,7 +116,6 @@ class NgapTask : public NtsTask
     void receiveInitialContextSetup(int amfId, ASN_NGAP_InitialContextSetupRequest *msg);
     void receiveContextRelease(int amfId, ASN_NGAP_UEContextReleaseCommand *msg);
     void receiveContextModification(int amfId, ASN_NGAP_UEContextModificationRequest *msg);
-    void sendContextRelease(int ueId, NgapCause cause);
 
     /* NAS Node Selection */
     NgapAmfContext *selectAmf(int ueId, int32_t &requestedSliceType);

--- a/src/gnb/rls/task.cpp
+++ b/src/gnb/rls/task.cpp
@@ -12,6 +12,8 @@
 #include <gnb/rrc/task.hpp>
 #include <utils/common.hpp>
 #include <utils/random.hpp>
+#include <gnb/ngap/task.hpp>
+
 
 namespace nr::gnb
 {
@@ -54,6 +56,14 @@ void GnbRlsTask::onLoop()
         }
         case NmGnbRlsToRls::SIGNAL_LOST: {
             m_logger->debug("UE[%d] signal lost", w.ueId);
+
+            if (m_base->ngapTask != nullptr) {
+                m_logger->info("Triggering UE Context Release Request for UE[%d]", w.ueId);
+                m_base->ngapTask->sendContextRelease(w.ueId, NgapCause::RadioNetwork_radio_connection_with_ue_lost);
+            } else {
+                m_logger->err("NGAP task not available, cannot send context release");
+            }
+
             break;
         }
         case NmGnbRlsToRls::UPLINK_DATA: {


### PR DESCRIPTION
Hello,

This simple implementation makes sure, that after UE is deregistered from the nr-gnb, it sends the signal further to the 5G core - specifically to AMF.

Here are logs from AMF component that shows how it received the signal:
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/565a9314-4792-4cbc-8d7e-97964ac4dd82" />

If needed I would be more than happy to provide more information.

