### PR TITLE
Akma derivation implementation

### DIFF
--- a/src/ue/nas/keys.cpp
+++ b/src/ue/nas/keys.cpp
@@ -16,6 +16,7 @@ static const int N_RRC_enc_alg = 0x03;
 static const int N_RRC_int_alg = 0x04;
 static const int N_UP_enc_alg = 0x05;
 static const int N_UP_int_alg = 0x06;
+static const int KAKMA_derivation_function_code = 0x6A
 
 namespace nr::ue::keys
 {
@@ -152,6 +153,15 @@ OctetString CalculateAuts(const OctetString &sqn, const OctetString &ak, const O
     OctetString auts = OctetString::Xor(sqn, ak);
     auts.append(macS);
     return auts;
+}
+
+OctetString CalculateAkmaKey(const OctetString &kAusf, const Supi &supi)
+{
+    OctetString inputParams[2];
+    inputParams[0] = crypto::EncodeKdfString(supi.value);
+    inputParams[1] = crypto::EncodeKdfString(rid);
+
+    return crypto::CalculateKdfKey(kAusf, KAKMA_derivation_function_code, inputParams, 2);
 }
 
 } // namespace nr::ue::keys

--- a/src/ue/nas/keys.hpp
+++ b/src/ue/nas/keys.hpp
@@ -76,4 +76,9 @@ OctetString CalculateResStar(const OctetString &key, const std::string &snn, con
  */
 OctetString CalculateAuts(const OctetString &sqn, const OctetString &ak, const OctetString &macS);
 
+/*
+ * Derives K_AKMA from K_AUSF and SUPI according to 3GPP TS 33.535
+ */
+ OctetString CalculateAkmaKey(const OctetString &kAusf, const Supi &supi);
+
 } // namespace nr::ue::keys

--- a/src/ue/nas/mm/auth.cpp
+++ b/src/ue/nas/mm/auth.cpp
@@ -363,6 +363,7 @@ void NasMm::receiveAuthenticationRequest5gAka(const nas::AuthenticationRequest &
         m_usim->m_nonCurrentNsCtx->tsc = msg.ngKSI.tsc;
         m_usim->m_nonCurrentNsCtx->ngKsi = msg.ngKSI.ksi;
         m_usim->m_nonCurrentNsCtx->keys.kAusf = keys::CalculateKAusfFor5gAka(milenage.ck, milenage.ik, snn, sqnXorAk);
+        m_usim->m_nonCurrentNsCtx->keys.kAkma = keys::CalculateAkmaKey(m_usim->m_nonCurrentNsCtx->keys.kAusf, m_base->config->supi.value())
         m_usim->m_nonCurrentNsCtx->keys.abba = msg.abba.rawData.copy();
 
         keys::DeriveKeysSeafAmf(*m_base->config, currentPLmn, *m_usim->m_nonCurrentNsCtx);

--- a/src/ue/types.hpp
+++ b/src/ue/types.hpp
@@ -402,6 +402,7 @@ struct UeKeys
     OctetString kAmf{};
     OctetString kNasInt{};
     OctetString kNasEnc{};
+    OctetString kAkma{};
 
     [[nodiscard]] UeKeys deepCopy() const
     {


### PR DESCRIPTION
As specified on **3GPP TS 33.535**: AKMA is meant o securely manage authentication keys for lightweight, low-latency access to services that may be near the edge of the network (like edge apps) — without needing a full 5G Core authentication each time. AKMA enables fast and secure authentication to edge services after a device has already authenticated to the 5G Core — avoiding delays and saving resources.

✅ It's meant for edge apps and services.
✅ It's about making authentication faster and lighter.
✅ It's NOT about completely replacing normal 5G authentication — it's an optimization after it.
