### PR TITLE
Fix CalculateAkmaKey function: remove reference to inexistent rid

### DIFF
--- a/src/ue/nas/keys.cpp
+++ b/src/ue/nas/keys.cpp
@@ -157,11 +157,11 @@ OctetString CalculateAuts(const OctetString &sqn, const OctetString &ak, const O
 
 OctetString CalculateAkmaKey(const OctetString &kAusf, const Supi &supi)
 {
-    OctetString inputParams[2];
+    OctetString inputParams[1];
     inputParams[0] = crypto::EncodeKdfString(supi.value);
-    inputParams[1] = crypto::EncodeKdfString(rid);
 
-    return crypto::CalculateKdfKey(kAusf, KAKMA_derivation_function_code, inputParams, 2);
+    return crypto::CalculateKdfKey(kAusf, KAKMA_derivation_function_code, inputParams, 1);
 }
+
 
 } // namespace nr::ue::keys


### PR DESCRIPTION
The code was making reference to an inexistent parameter, which was the rid (akma routing indicator). Which is unecessary on the UE side.