### PR TITLE
Don't auto-fail tun allocation for non-root users

### DIFF
--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -147,12 +147,6 @@ void UeAppTask::receiveStatusUpdate(NmUeStatusUpdate &msg)
 
 void UeAppTask::setupTunInterface(const PduSession *pduSession)
 {
-    if (!utils::IsRoot())
-    {
-        m_logger->err("TUN interface could not be setup. Permission denied. Please run the UE with 'sudo'");
-        return;
-    }
-
     if (!pduSession->pduAddress.has_value())
     {
         m_logger->err("Connection could not setup. PDU address is missing.");

--- a/src/utils/common.cpp
+++ b/src/utils/common.cpp
@@ -20,7 +20,6 @@
 #include <thread>
 
 #include <arpa/inet.h>
-#include <unistd.h>
 
 static_assert(sizeof(char) == sizeof(uint8_t));
 static_assert(sizeof(int) == sizeof(uint32_t));
@@ -277,11 +276,6 @@ std::string utils::OctetStringToIp(const OctetString &address)
         return std::string{buffer};
     }
     return address.toHexString();
-}
-
-bool utils::IsRoot()
-{
-    return geteuid() == 0;
 }
 
 void utils::AssertNodeName(const std::string &str)

--- a/src/utils/common.hpp
+++ b/src/utils/common.hpp
@@ -35,7 +35,6 @@ int ParseInt(const char *str);
 bool TryParseInt(const std::string &str, int &output);
 bool TryParseInt(const char *str, int &output);
 void Sleep(int ms);
-bool IsRoot();
 bool IsNumeric(const std::string &str);
 void AssertNodeName(const std::string &str);
 void Trim(std::string &str);


### PR DESCRIPTION
In case the process has the necessary capability (CAP_NET_ADMIN), this will actually succeed, with this check being an arbitrary limitation.