### PR TITLE
Fix missing header caused compilation error

### DIFF
--- a/src/ext/yaml-cpp/emitterutils.cpp
+++ b/src/ext/yaml-cpp/emitterutils.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <cstdint>
 
 #include "emitterutils.h"
 #include "exp.h"

--- a/src/lib/rlc/encoder.hpp
+++ b/src/lib/rlc/encoder.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils.hpp"
+#include <cstdint>
 
 namespace rlc
 {

--- a/src/lib/rlc/utils.hpp
+++ b/src/lib/rlc/utils.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>

--- a/src/utils/json.hpp
+++ b/src/utils/json.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <initializer_list>
 #include <map>
 #include <memory>


### PR DESCRIPTION
## Description

I'm using Arch Linux to build UERANSIM (thought it seems unsupported). 

I build UERANSIM with GCC 14.2.1 and found the compilation error. It seems `cstdint` header is missing, so I add this.

## How to review it?

 - Check the compilation is work properly.