### PR TITLE
Feat: add Ethernet PDU support via TAP

### DIFF
--- a/src/gnb/gtp/task.cpp
+++ b/src/gnb/gtp/task.cpp
@@ -180,12 +180,6 @@ void GtpTask::handleUeContextDelete(int ueId)
 
 void GtpTask::handleUplinkData(int ueId, int psi, OctetString &&pdu)
 {
-    const uint8_t *data = pdu.data();
-
-    // ignore non IPv4 packets
-    if ((data[0] >> 4 & 0xF) != 4)
-        return;
-
     uint64_t sessionInd = MakeSessionResInd(ueId, psi);
 
     if (!m_pduSessions.count(sessionInd))
@@ -195,6 +189,15 @@ void GtpTask::handleUplinkData(int ueId, int psi, OctetString &&pdu)
     }
 
     auto &pduSession = m_pduSessions[sessionInd];
+
+    // For IPv4 sessions, filter non-IPv4 packets (IP version in first nibble). Ethernet sessions carry raw L2 frames.
+    if (pduSession->sessionType == PduSessionType::IPv4)
+    {
+        if (pdu.length() < 1)
+            return;
+        if ((pdu.data()[0] >> 4 & 0xF) != 4)
+            return;
+    }
 
     if (m_rateLimiter->allowUplinkPacket(sessionInd, static_cast<int64_t>(pdu.length())))
     {

--- a/src/gnb/ngap/session.cpp
+++ b/src/gnb/ngap/session.cpp
@@ -215,9 +215,9 @@ void NgapTask::receiveSessionResourceSetupRequest(int amfId, ASN_NGAP_PDUSession
 
 std::optional<NgapCause> NgapTask::setupPduSessionResource(NgapUeContext *ue, PduSessionResource *resource)
 {
-    if (resource->sessionType != PduSessionType::IPv4)
+    if (resource->sessionType != PduSessionType::IPv4 && resource->sessionType != PduSessionType::ETHERNET)
     {
-        m_logger->err("PDU session resource could not setup: Only IPv4 is supported");
+        m_logger->err("PDU session resource could not setup: Only IPv4 and Ethernet are supported");
         return NgapCause::RadioNetwork_unspecified;
     }
 

--- a/src/lib/app/cli_cmd.cpp
+++ b/src/lib/app/cli_cmd.cpp
@@ -127,10 +127,11 @@ static opt::OptionsDescription DefaultDesc(const std::string &subCommand, const 
 static opt::OptionsDescription DescForPsEstablish(const std::string &subCommand, const CmdEntry &entry)
 {
     std::string example1 = "IPv4 --sst 1 --sd 1 --dnn internet";
-    std::string example2 = "IPv4 --emergency";
+    std::string example2 = "Ethernet --sst 1 --sd 1 --dnn internet";
+    std::string example3 = "IPv4 --emergency";
 
     auto res = opt::OptionsDescription{
-        {},  {}, entry.descriptionText, {}, subCommand, {entry.usageText}, {example1, example2}, entry.helpIfEmpty,
+        {},  {}, entry.descriptionText, {}, subCommand, {entry.usageText}, {example1, example2, example3}, entry.helpIfEmpty,
         true};
 
     res.items.emplace_back(std::nullopt, "sst", "SST value of the PDU session", "value");
@@ -289,8 +290,10 @@ static std::unique_ptr<UeCliCommand> UeCliParseImpl(const std::string &subCmd, c
         if (options.positionalCount() > 15)
             CMD_ERR("Only one PDU session type is expected")
         std::string type = options.getPositional(0);
-        if (type != "IPv4" && type != "ipv4" && type != "IPV4" && type != "Ipv4" && type != "IpV4")
-            CMD_ERR("Only IPv4 is supported for now")
+        if (type != "IPv4" && type != "ipv4" && type != "IPV4" && type != "Ipv4" && type != "IpV4" &&
+            type != "Ethernet" && type != "ethernet" && type != "ETHERNET" && type != "Ethernet" && type != "EtherNet")
+            CMD_ERR("Only IPv4 and Ethernet are supported")
+        cmd->sessionTypeStr = type;
         cmd->isEmergency = options.hasFlag('e', "emergency");
         if (cmd->isEmergency)
         {

--- a/src/lib/app/cli_cmd.hpp
+++ b/src/lib/app/cli_cmd.hpp
@@ -69,6 +69,7 @@ struct UeCliCommand
     std::optional<SingleSlice> sNssai{};
     std::optional<std::string> apn{};
     bool isEmergency{};
+    std::optional<std::string> sessionTypeStr{}; // Store the session type string for parsing
 
     explicit UeCliCommand(PR present) : present(present)
     {

--- a/src/ue/app/cmd_handler.cpp
+++ b/src/ue/app/cmd_handler.cpp
@@ -186,7 +186,21 @@ void UeCmdHandler::handleCmdImpl(NmUeCliCommand &msg)
     }
     case app::UeCliCommand::PS_ESTABLISH: {
         SessionConfig config;
-        config.type = nas::EPduSessionType::IPV4;
+        // Parse session type from command string
+        if (msg.cmd->sessionTypeStr.has_value())
+        {
+            std::string type = msg.cmd->sessionTypeStr.value();
+            if (type == "IPv4" || type == "ipv4" || type == "IPV4" || type == "Ipv4" || type == "IpV4")
+                config.type = nas::EPduSessionType::IPV4;
+            else if (type == "Ethernet" || type == "ethernet" || type == "ETHERNET" || type == "Ethernet" || type == "EtherNet")
+                config.type = nas::EPduSessionType::ETHERNET;
+            else
+                config.type = nas::EPduSessionType::IPV4; // Default fallback
+        }
+        else
+        {
+            config.type = nas::EPduSessionType::IPV4; // Default for backward compatibility
+        }
         config.isEmergency = msg.cmd->isEmergency;
         config.apn = msg.cmd->apn;
         config.sNssai = msg.cmd->sNssai;

--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -8,10 +8,12 @@
 
 #include "task.hpp"
 #include "cmd_handler.hpp"
+#include <unistd.h>
 #include <lib/nas/utils.hpp>
 #include <ue/nas/task.hpp>
 #include <ue/rls/task.hpp>
 #include <ue/tun/tun.hpp>
+#include <ue/tap/tap.hpp>
 #include <utils/common.hpp>
 #include <utils/constants.hpp>
 
@@ -41,6 +43,15 @@ void UeAppTask::onQuit()
             tunTask = nullptr;
         }
     }
+    for (auto &tapTask : m_tapTasks)
+    {
+        if (tapTask != nullptr)
+        {
+            tapTask->quit();
+            delete tapTask;
+            tapTask = nullptr;
+        }
+    }
 }
 
 void UeAppTask::onLoop()
@@ -63,7 +74,7 @@ void UeAppTask::onLoop()
             break;
         }
         case NmUeTunToApp::TUN_ERROR: {
-            m_logger->err("TUN failure [%s]", w.error.c_str());
+            m_logger->err("TUN/TAP failure [%s]", w.error.c_str());
             break;
         }
         }
@@ -79,12 +90,20 @@ void UeAppTask::onLoop()
         }
         case NmUeNasToApp::DOWNLINK_DATA_DELIVERY: {
             auto *tunTask = m_tunTasks[w.psi];
+            auto *tapTask = m_tapTasks[w.psi];
             if (tunTask)
             {
                 auto m = std::make_unique<NmAppToTun>(NmAppToTun::DATA_PDU_DELIVERY);
                 m->psi = w.psi;
                 m->data = std::move(w.data);
                 tunTask->push(std::move(m));
+            }
+            else if (tapTask)
+            {
+                auto m = std::make_unique<NmAppToTun>(NmAppToTun::DATA_PDU_DELIVERY);
+                m->psi = w.psi;
+                m->data = std::move(w.data);
+                tapTask->push(std::move(m));
             }
             break;
         }
@@ -122,7 +141,10 @@ void UeAppTask::receiveStatusUpdate(NmUeStatusUpdate &msg)
     {
         auto *session = msg.pduSession;
 
-        setupTunInterface(session);
+        if (session->sessionType == nas::EPduSessionType::ETHERNET)
+            setupTapInterface(session);
+        else
+            setupTunInterface(session);
         return;
     }
 
@@ -133,6 +155,12 @@ void UeAppTask::receiveStatusUpdate(NmUeStatusUpdate &msg)
             m_tunTasks[msg.psi]->quit();
             delete m_tunTasks[msg.psi];
             m_tunTasks[msg.psi] = nullptr;
+        }
+        if (m_tapTasks[msg.psi] != nullptr)
+        {
+            m_tapTasks[msg.psi]->quit();
+            delete m_tapTasks[msg.psi];
+            m_tapTasks[msg.psi] = nullptr;
         }
 
         return;
@@ -147,6 +175,7 @@ void UeAppTask::receiveStatusUpdate(NmUeStatusUpdate &msg)
 
 void UeAppTask::setupTunInterface(const PduSession *pduSession)
 {
+
     if (!utils::IsRoot())
     {
         m_logger->err("TUN interface could not be setup. Permission denied. Please run the UE with 'sudo'");
@@ -209,6 +238,53 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
 
     m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up.", pduSession->psi,
                    allocatedName.c_str(), ipAddress.c_str());
+}
+
+void UeAppTask::setupTapInterface(const PduSession *pduSession)
+{
+    if (!utils::IsRoot())
+    {
+        m_logger->err("TAP interface could not be setup. Permission denied. Please run the UE with 'sudo'");
+        return;
+    }
+
+    int psi = pduSession->psi;
+    if (psi == 0 || psi > 15)
+    {
+        m_logger->err("Connection could not setup. Invalid PSI.");
+        return;
+    }
+
+    if (m_tapTasks[psi] != nullptr)
+    {
+        m_logger->err("Connection could not setup. TAP task for specified PSI is non-null.");
+        return;
+    }
+
+    std::string error{}, allocatedName{};
+    std::string requestedName = cons::TapNamePrefix;
+
+    int fd = tap::TapAllocate(requestedName.c_str(), allocatedName, error);
+    if (fd == 0 || error.length() > 0)
+    {
+        m_logger->err("TAP allocation failure [%s]", error.c_str());
+        return;
+    }
+
+    bool r = tap::TapConfigure(allocatedName, cons::TunMtu, error);
+    if (!r || error.length() > 0)
+    {
+        m_logger->err("TAP configuration failure [%s]", error.c_str());
+        ::close(fd);
+        return;
+    }
+
+    auto *task = new TapTask(m_base, psi, fd);
+    m_tapTasks[psi] = task;
+    task->start();
+
+    m_logger->info("Connection setup for Ethernet PDU session[%d] is successful, TAP interface[%s] is up.", 
+                   pduSession->psi, allocatedName.c_str());
 }
 
 } // namespace nr::ue

--- a/src/ue/nas/sm/allocation.cpp
+++ b/src/ue/nas/sm/allocation.cpp
@@ -14,7 +14,7 @@ namespace nr::ue
 
 int NasSm::allocatePduSessionId(const SessionConfig &config)
 {
-    if (config.type != nas::EPduSessionType::IPV4)
+    if (config.type != nas::EPduSessionType::IPV4 && config.type != nas::EPduSessionType::ETHERNET)
     {
         m_logger->debug("PDU session type [%s] is not supported", nas::utils::EnumToString(config.type));
         return 0;

--- a/src/ue/nas/sm/establishment.cpp
+++ b/src/ue/nas/sm/establishment.cpp
@@ -54,7 +54,7 @@ void NasSm::sendEstablishmentRequest(const SessionConfig &config)
     }
 
     /* Control the received config */
-    if (config.type != nas::EPduSessionType::IPV4)
+    if (config.type != nas::EPduSessionType::IPV4 && config.type != nas::EPduSessionType::ETHERNET)
     {
         m_logger->err("PDU session type [%s] is not supported", nas::utils::EnumToString(config.type));
         return;
@@ -99,10 +99,18 @@ void NasSm::sendEstablishmentRequest(const SessionConfig &config)
 
     /* Make PCO */
     nas::ProtocolConfigurationOptions opt{};
-    opt.additionalParams.push_back(std::make_unique<nas::ProtocolConfigurationItem>(
-        nas::EProtocolConfigId::CONT_ID_UP_IP_ADDRESS_ALLOCATION_VIA_NAS_SIGNALLING, true, OctetString::Empty()));
-    opt.additionalParams.push_back(std::make_unique<nas::ProtocolConfigurationItem>(
-        nas::EProtocolConfigId::CONT_ID_DOWN_DNS_SERVER_IPV4_ADDRESS, true, OctetString::Empty()));
+    if (config.type == nas::EPduSessionType::IPV4)
+    {
+        opt.additionalParams.push_back(std::make_unique<nas::ProtocolConfigurationItem>(
+            nas::EProtocolConfigId::CONT_ID_UP_IP_ADDRESS_ALLOCATION_VIA_NAS_SIGNALLING, true, OctetString::Empty()));
+        opt.additionalParams.push_back(std::make_unique<nas::ProtocolConfigurationItem>(
+            nas::EProtocolConfigId::CONT_ID_DOWN_DNS_SERVER_IPV4_ADDRESS, true, OctetString::Empty()));
+    }
+    else if (config.type == nas::EPduSessionType::ETHERNET)
+    {
+        opt.additionalParams.push_back(std::make_unique<nas::ProtocolConfigurationItem>(
+            nas::EProtocolConfigId::CONT_ID_UP_ETHERNET_FRAME_PAYLOAD_MTU_REQUEST, true, OctetString::Empty()));
+    }
 
     nas::IEExtendedProtocolConfigurationOptions iePco{};
     iePco.configurationProtocol = nas::EConfigurationProtocol::PPP;
@@ -115,7 +123,7 @@ void NasSm::sendEstablishmentRequest(const SessionConfig &config)
     req->pduSessionId = psi;
     req->integrityProtectionMaximumDataRate = MakeIntegrityMaxRate(m_base->config->integrityMaxRate);
     req->pduSessionType = nas::IEPduSessionType{};
-    req->pduSessionType->pduSessionType = nas::EPduSessionType::IPV4;
+    req->pduSessionType->pduSessionType = config.type;
     req->sscMode = nas::IESscMode{};
     req->sscMode->sscMode = nas::ESscMode::SSC_MODE_1;
     req->extendedProtocolConfigurationOptions = std::move(iePco);

--- a/src/ue/tap/config.cpp
+++ b/src/ue/tap/config.cpp
@@ -1,0 +1,148 @@
+
+#include "config.hpp"
+#include <ue/tun/config.hpp>
+
+#include <arpa/inet.h>
+#include <array>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <ifaddrs.h>
+#include <iostream>
+#include <linux/if_tun.h>
+#include <memory>
+#include <mutex>
+#include <net/if.h>
+#include <set>
+#include <sstream>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include <utils/libc_error.hpp>
+
+
+namespace nr::ue::tap
+{
+
+static const char *NextInterfaceName(const std::string &prefix)
+{
+    std::set<std::string> names;
+
+    struct ifaddrs *addrs, *tmp;
+
+    getifaddrs(&addrs);
+    tmp = addrs;
+
+    while (tmp)
+    {
+        std::string name = tmp->ifa_name;
+        if (name.rfind(prefix, 0) == 0)
+            names.insert(name);
+        tmp = tmp->ifa_next;
+    }
+
+    freeifaddrs(addrs);
+
+    for (int i = 0; i < MAX_INTERFACE_COUNT; i++)
+    {
+        std::string name = prefix + std::to_string(i);
+        if (!names.count(name))
+            return strdup(name.c_str());
+    }
+    return nullptr;
+}
+
+
+static void TapSetUp(const char *ifName, int mtu)
+{
+    ifreq ifr{};
+    memset(&ifr, 0, sizeof(struct ifreq));
+
+    int sockFd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockFd < 0)
+        throw LibError("socket() failed", errno);
+
+    strcpy(ifr.ifr_name, ifName);
+
+    if (ioctl(sockFd, SIOCGIFFLAGS, &ifr) < 0)
+    {
+        close(sockFd);
+        throw LibError("ioctl(SIOCGIFFLAGS)", errno);
+    }
+
+    ifr.ifr_mtu = mtu;
+    if (ioctl(sockFd, SIOCSIFMTU, &ifr) < 0)
+    {
+        close(sockFd);
+        throw LibError("ioctl(SIOCSIFMTU)", errno);
+    }
+
+    ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+    if (ioctl(sockFd, SIOCSIFFLAGS, &ifr) < 0)
+    {
+        close(sockFd);
+        throw LibError("ioctl(SIOCSIFFLAGS)", errno);
+    }
+
+    close(sockFd);
+}
+
+int AllocateTap(const char *ifPrefix, char **allocatedName)
+{
+    // acquire the configuration lock
+    const std::lock_guard<std::mutex> lock(ue::tun::configMutex);
+
+    const char *ifName = NextInterfaceName(ifPrefix);
+    if (!ifName)
+        throw LibError("TAP interface name could not be allocated.", errno);
+
+    char tapName[IFNAMSIZ];
+    strcpy(tapName, ifName);
+
+    ifreq ifr{};
+    int fd;
+
+    if ((fd = open("/dev/net/tun", O_RDWR)) < 0)
+        throw LibError("Open failure /dev/net/tun");
+
+    memset(&ifr, 0, sizeof(ifr));
+
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+
+    strncpy(ifr.ifr_name, tapName, IFNAMSIZ);
+
+    if (ioctl(fd, TUNSETIFF, (void *)&ifr) < 0)
+    {
+        close(fd);
+        throw LibError("ioctl(TUNSETIFF)", errno);
+    }
+
+    strcpy(tapName, ifr.ifr_name);
+    if (strcmp(tapName, ifName) != 0)
+        throw LibError("TAP interface name could not be allocated.");
+
+    *allocatedName = strdup(tapName);
+    return fd;
+}
+
+void ConfigureTap(const char *tapName, int mtu)
+{
+    // acquire the configuration lock
+    const std::lock_guard<std::mutex> lock(ue::tun::configMutex);
+
+    TapSetUp(tapName, mtu);
+}
+
+}

--- a/src/ue/tap/config.hpp
+++ b/src/ue/tap/config.hpp
@@ -1,0 +1,21 @@
+//
+// This file is a part of UERANSIM project.
+// Copyright (c) 2023 ALİ GÜNGÖR.
+//
+// https://github.com/aligungr/UERANSIM/
+// See README, LICENSE, and CONTRIBUTING files for licensing details.
+//
+
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace nr::ue::tap
+{
+
+int AllocateTap(const char *ifPrefix, char **allocatedName);
+void ConfigureTap(const char *tapName, int mtu);
+
+} // namespace nr::ue::tap

--- a/src/ue/tap/tap.cpp
+++ b/src/ue/tap/tap.cpp
@@ -1,0 +1,51 @@
+//
+// This file is a part of UERANSIM project.
+// Copyright (c) 2023 ALİ GÜNGÖR.
+//
+// https://github.com/aligungr/UERANSIM/
+// See README, LICENSE, and CONTRIBUTING files for licensing details.
+//
+
+#include "tap.hpp"
+#include "config.hpp"
+#include <utils/libc_error.hpp>
+
+
+namespace nr::ue::tap
+{
+
+int TapAllocate(const char *namePrefix, std::string &allocatedName, std::string &error)
+{
+    int fd;
+    char *name = nullptr;
+    try
+    {
+        fd = tap::AllocateTap(namePrefix, &name);
+        allocatedName = std::string{name};
+    }
+    catch (const LibError &e)
+    {
+        error = e.what();
+        allocatedName = "";
+        return 0;
+    }
+
+    return fd;
+}
+
+bool TapConfigure(const std::string &tapName, int mtu, std::string &error)
+{
+    try
+    {
+        tap::ConfigureTap(tapName.c_str(), mtu);
+    }
+    catch (const LibError &e)
+    {
+        error = e.what();
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/src/ue/tap/tap.hpp
+++ b/src/ue/tap/tap.hpp
@@ -1,0 +1,19 @@
+//
+// This file is a part of UERANSIM project.
+// Copyright (c) 2023 ALİ GÜNGÖR.
+//
+// https://github.com/aligungr/UERANSIM/
+// See README, LICENSE, and CONTRIBUTING files for licensing details.
+//
+
+#pragma once
+
+#include <string>
+
+namespace nr::ue::tap
+{
+
+int TapAllocate(const char *namePrefix, std::string &allocatedName, std::string &error);
+bool TapConfigure(const std::string &tapName, int mtu, std::string &error);
+
+} // namespace nr::ue::tap

--- a/src/ue/tap/task.cpp
+++ b/src/ue/tap/task.cpp
@@ -1,0 +1,123 @@
+//
+// This file is a part of UERANSIM project.
+// Copyright (c) 2023 ALİ GÜNGÖR.
+//
+// https://github.com/aligungr/UERANSIM/
+// See README, LICENSE, and CONTRIBUTING files for licensing details.
+//
+
+#include "task.hpp"
+#include <cstring>
+#include <ue/app/task.hpp>
+#include <ue/nts.hpp>
+#include <unistd.h>
+#include <utils/libc_error.hpp>
+#include <utils/scoped_thread.hpp>
+
+// TODO: May be reduced to MTU 1500
+#define RECEIVER_BUFFER_SIZE 8000
+
+struct TapReceiverArgs
+{
+    int fd{};
+    int psi{};
+    NtsTask *targetTask{};
+};
+
+static std::string GetTapErrorMessage(const std::string &cause)
+{
+    std::string what = cause;
+
+    int errNo = errno;
+    if (errNo != 0)
+        what += " (" + std::string{strerror(errNo)} + ")";
+
+    return what;
+}
+
+static std::unique_ptr<nr::ue::NmUeTunToApp> TapNmError(std::string &&error)
+{
+    auto m = std::make_unique<nr::ue::NmUeTunToApp>(nr::ue::NmUeTunToApp::TUN_ERROR);
+    m->error = std::move(error);
+    return m;
+}
+
+static void TapReceiverThread(TapReceiverArgs *args)
+{
+    int fd = args->fd;
+    int psi = args->psi;
+    NtsTask *targetTask = args->targetTask;
+
+    delete args;
+
+    uint8_t buffer[RECEIVER_BUFFER_SIZE];
+
+    while (true)
+    {
+        ssize_t n = ::read(fd, buffer, RECEIVER_BUFFER_SIZE);
+        if (n < 0)
+        {
+            targetTask->push(TapNmError(GetTapErrorMessage("TAP device could not read")));
+            return; // Abort receiver thread
+        }
+
+        if (n > 0)
+        {
+            auto m = std::make_unique<nr::ue::NmUeTunToApp>(nr::ue::NmUeTunToApp::DATA_PDU_DELIVERY);
+            m->psi = psi;
+            m->data = OctetString::FromArray(buffer, static_cast<size_t>(n));
+            targetTask->push(std::move(m));
+        }
+    }
+}
+
+namespace nr::ue
+{
+
+ue::TapTask::TapTask(TaskBase *base, int psi, int fd) : m_base{base}, m_psi{psi}, m_fd{fd}, m_receiver{}
+{
+}
+
+void TapTask::onStart()
+{
+    auto *receiverArgs = new TapReceiverArgs();
+    receiverArgs->fd = m_fd;
+    receiverArgs->targetTask = this;
+    receiverArgs->psi = m_psi;
+    m_receiver =
+        new ScopedThread([](void *args) { TapReceiverThread(reinterpret_cast<TapReceiverArgs *>(args)); }, receiverArgs);
+}
+
+void TapTask::onQuit()
+{
+    delete m_receiver;
+    ::close(m_fd);
+}
+
+void TapTask::onLoop()
+{
+    auto msg = take();
+    if (!msg)
+        return;
+
+    switch (msg->msgType)
+    {
+    case NtsMessageType::UE_APP_TO_TUN: {
+        auto &w = dynamic_cast<NmAppToTun &>(*msg);
+        ssize_t res = ::write(m_fd, w.data.data(), w.data.length());
+        if (res < 0)
+            push(TapNmError(GetTapErrorMessage("TAP device could not write")));
+        else if (res != w.data.length())
+            push(TapNmError(GetTapErrorMessage("TAP device partially written")));
+        break;
+    }
+    case NtsMessageType::UE_TUN_TO_APP: {
+        m_base->appTask->push(std::move(msg));
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+} // namespace nr::ue

--- a/src/ue/tap/task.hpp
+++ b/src/ue/tap/task.hpp
@@ -11,8 +11,6 @@
 #include <memory>
 #include <thread>
 #include <ue/nts.hpp>
-#include <ue/tun/task.hpp>
-#include <ue/tap/task.hpp>
 #include <ue/types.hpp>
 #include <unordered_map>
 #include <utils/logger.hpp>
@@ -22,31 +20,24 @@
 namespace nr::ue
 {
 
-class UeAppTask : public NtsTask
+class TapTask : public NtsTask
 {
   private:
     TaskBase *m_base;
-    std::unique_ptr<Logger> m_logger;
-
-    std::array<TunTask *, 16> m_tunTasks{};
-    std::array<TapTask *, 16> m_tapTasks{};
-    ECmState m_cmState{};
+    int m_psi;
+    int m_fd;
+    ScopedThread *m_receiver;
 
     friend class UeCmdHandler;
 
   public:
-    explicit UeAppTask(TaskBase *base);
-    ~UeAppTask() override = default;
+    explicit TapTask(TaskBase *taskBase, int psi, int fd);
+    ~TapTask() override = default;
 
   protected:
     void onStart() override;
     void onLoop() override;
     void onQuit() override;
-
-  private:
-    void receiveStatusUpdate(NmUeStatusUpdate &msg);
-    void setupTunInterface(const PduSession *pduSession);
-    void setupTapInterface(const PduSession *pduSession);
 };
 
 } // namespace nr::ue

--- a/src/ue/tun/config.cpp
+++ b/src/ue/tun/config.cpp
@@ -38,10 +38,6 @@
 
 #include <utils/libc_error.hpp>
 
-#define ROUTING_TABLE_PREFIX "rt_"
-#define MAX_INTERFACE_COUNT 1024
-
-static std::mutex configMutex;
 
 static int ExecOutput(const char *cmd, std::string &output)
 {
@@ -378,5 +374,6 @@ void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, 
         AddIpRoutes(tunName, table_name);
     }
 }
+
 
 } // namespace nr::ue::tun

--- a/src/ue/tun/config.hpp
+++ b/src/ue/tun/config.hpp
@@ -11,9 +11,14 @@
 #include <sstream>
 #include <string>
 #include <utility>
+#include <mutex>
+
+#define ROUTING_TABLE_PREFIX "rt_"
+#define MAX_INTERFACE_COUNT 1024
 
 namespace nr::ue::tun
 {
+static std::mutex configMutex;
 
 int AllocateTun(const char *ifPrefix, char **allocatedName);
 void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, int mtu, bool configureRoute);

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -30,6 +30,9 @@ struct cons
     static constexpr const char *TunNetmask = "255.255.0.0";
     static constexpr const int TunMtu = 1400;
 
+    // TAP interface (Ethernet PDU sessions)
+    static constexpr const char *TapNamePrefix = "uesimtap";
+
     // Constraints
     static constexpr const int MinNodeName = 3;
     static constexpr const int MaxNodeName = 1024;

--- a/tools/ether-ping.py
+++ b/tools/ether-ping.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""TAP Interface Ping — Ethernet PDU E2E Test
+
+Sends ICMP pings over a TAP interface created by a UERANSIM.
+UERANSIM handles GTP-U encapsulation; this script just injects
+raw Ethernet frames into the TAP to verify end-to-end connectivity
+through the UPF.
+
+Flow:
+  1. Send ARP request on the TAP to trigger MAC learning
+  2. Listen for ARP replies and ICMP echo replies
+  3. Send ICMP Echo Requests, print Echo Replies with RTT
+"""
+import sys
+import time
+import threading
+from scapy.all import *
+
+if len(sys.argv) < 4:
+    print("Usage: python tap-ping.py <ue_ip> <target_ip> <tap_iface> [ue_mac] [count]")
+    print()
+    print("  ue_ip       UE IP address assigned to the PDU session")
+    print("  target_ip   IP to ping on the N6 / data network")
+    print("  tap_iface   TAP interface name (e.g. uesimtun0)")
+    print("  ue_mac      UE MAC address (default: TAP interface MAC)")
+    print("  count       Number of pings, 0=infinite (default: 4)")
+    sys.exit(1)
+
+ue_ip = sys.argv[1]
+target_ip = sys.argv[2]
+tap = sys.argv[3]
+ue_mac = sys.argv[4] if len(sys.argv) > 4 else get_if_hwaddr(tap)
+count = int(sys.argv[5]) if len(sys.argv) > 5 else 4
+
+target_mac = None
+pending = {}
+lock = threading.Lock()
+stats = {'sent': 0, 'recv': 0, 'rtt': []}
+
+
+def handle_pkt(pkt):
+    global target_mac
+
+    if not pkt.haslayer(Ether):
+        return
+
+    if pkt.haslayer(ARP):
+        arp = pkt[ARP]
+        if arp.op == 1 and arp.pdst == ue_ip:
+            print(f"  << ARP who-has {arp.pdst}? tell {arp.psrc} [{arp.hwsrc}]")
+            if target_mac is None:
+                target_mac = arp.hwsrc
+            reply = (Ether(dst=arp.hwsrc, src=ue_mac) /
+                     ARP(op=2, hwsrc=ue_mac, psrc=ue_ip,
+                         hwdst=arp.hwsrc, pdst=arp.psrc))
+            sendp(reply, iface=tap, verbose=False)
+            print(f"  >> ARP reply: {ue_ip} is-at {ue_mac}")
+        elif arp.op == 2 and arp.pdst == ue_ip:
+            print(f"  << ARP reply: {arp.psrc} is-at {arp.hwsrc}")
+            target_mac = arp.hwsrc
+
+    elif pkt.haslayer(IP) and pkt.haslayer(ICMP):
+        ip_l = pkt[IP]
+        icmp_l = pkt[ICMP]
+
+        if icmp_l.type == 0 and ip_l.dst == ue_ip:
+            seq = icmp_l.seq
+            with lock:
+                send_time = pending.pop(seq, None)
+                stats['recv'] += 1
+            rtt_ms = (time.time() - send_time) * 1000 if send_time else 0
+            if send_time:
+                stats['rtt'].append(rtt_ms)
+            print(f"  << ICMP reply from {ip_l.src}: seq={seq} time={rtt_ms:.1f}ms")
+
+        elif icmp_l.type == 8 and ip_l.dst == ue_ip:
+            print(f"  << ICMP request from {ip_l.src}: seq={icmp_l.seq}")
+            reply = (Ether(dst=pkt[Ether].src, src=ue_mac) /
+                     IP(src=ip_l.dst, dst=ip_l.src) /
+                     ICMP(type=0, id=icmp_l.id, seq=icmp_l.seq) /
+                     Raw(load=raw(icmp_l.payload)))
+            sendp(reply, iface=tap, verbose=False)
+            print(f"  >> ICMP reply to {ip_l.src}")
+
+
+print(f"PING {target_ip} from {ue_ip} [{ue_mac}] via {tap}")
+print()
+
+sniffer = AsyncSniffer(iface=tap, prn=handle_pkt, store=False)
+sniffer.start()
+time.sleep(0.3)
+
+arp_req = (Ether(dst='ff:ff:ff:ff:ff:ff', src=ue_mac) /
+           ARP(op=1, hwsrc=ue_mac, psrc=ue_ip, pdst=target_ip))
+sendp(arp_req, iface=tap, verbose=False)
+print(f"  >> ARP who-has {target_ip}?")
+time.sleep(1)
+
+try:
+    seq = 1
+    while count == 0 or seq <= count:
+        dst = target_mac or 'ff:ff:ff:ff:ff:ff'
+        ping = (Ether(dst=dst, src=ue_mac) /
+                IP(src=ue_ip, dst=target_ip) /
+                ICMP(type=8, id=0x1234, seq=seq))
+        with lock:
+            pending[seq] = time.time()
+            stats['sent'] += 1
+        sendp(ping, iface=tap, verbose=False)
+        print(f"  >> ICMP request to {target_ip}: seq={seq}")
+        seq += 1
+        time.sleep(1)
+except KeyboardInterrupt:
+    pass
+
+time.sleep(2)
+sniffer.stop()
+
+print(f"\n--- {target_ip} ping statistics ---")
+loss = 100 - (stats['recv'] / max(stats['sent'], 1) * 100)
+print(f"{stats['sent']} sent, {stats['recv']} received, {loss:.0f}% loss")
+if stats['rtt']:
+    print(f"rtt min/avg/max = {min(stats['rtt']):.1f}/{sum(stats['rtt'])/len(stats['rtt']):.1f}/{max(stats['rtt']):.1f} ms")


### PR DESCRIPTION
This PR adds Ethernet PDU support via TAP interface.
The UPF needs to support Ethernet GTP De-/Encapsulation and the core needs to be able to handle Session Type 5.