### PR TITLE
feat: add optional UE TUN network namespace support with teardown cleanup

### DIFF
--- a/config/custom-ue.yaml
+++ b/config/custom-ue.yaml
@@ -29,6 +29,12 @@ imeiSv: '4370816125816151'
 # Network mask used for the UE's TUN interface to define the subnet size
 tunNetmask: '255.255.255.0'
 
+# Create the UE TUN interface inside a dedicated Linux network namespace.
+useNamespace: false
+
+# Optional prefix used when deriving the namespace name.
+nsNamePrefix: 'ueransim'
+
 # List of gNB IP addresses for Radio Link Simulation
 gnbSearchList:
   - 127.0.0.1

--- a/src/ue.cpp
+++ b/src/ue.cpp
@@ -164,6 +164,10 @@ static nr::ue::UeConfig *ReadConfigYaml()
         result->tunName = yaml::GetString(config, "tunName", 1, 12);
     if (yaml::HasField(config, "tunNetmask"))
         result->tunNetmask = yaml::GetString(config, "tunNetmask", 9, 15);
+    if (yaml::HasField(config, "useNamespace"))
+        result->useNamespace = yaml::GetBool(config, "useNamespace");
+    if (yaml::HasField(config, "nsNamePrefix"))
+        result->nsNamePrefix = yaml::GetString(config, "nsNamePrefix", 1, 64);
 
     yaml::AssertHasField(config, "integrity");
     yaml::AssertHasField(config, "ciphering");
@@ -363,6 +367,8 @@ static nr::ue::UeConfig *GetConfigByUe(int ueIndex)
     c->routingIndicator = g_refConfig->routingIndicator;
     c->tunName = g_refConfig->tunName;
     c->tunNetmask = g_refConfig->tunNetmask;
+    c->useNamespace = g_refConfig->useNamespace;
+    c->nsNamePrefix = g_refConfig->nsNamePrefix;
     c->hplmn = g_refConfig->hplmn;
     c->configuredNssai = g_refConfig->configuredNssai;
     c->defaultConfiguredNssai = g_refConfig->defaultConfiguredNssai;

--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -9,11 +9,11 @@
 #include "task.hpp"
 #include "cmd_handler.hpp"
 #include <cctype>
-#include <unistd.h>
 #include <lib/nas/utils.hpp>
 #include <ue/nas/task.hpp>
 #include <ue/rls/task.hpp>
 #include <ue/tun/tun.hpp>
+#include <unistd.h>
 #include <utils/common.hpp>
 #include <utils/constants.hpp>
 
@@ -44,8 +44,9 @@ static std::string BuildNamespaceName(const nr::ue::UeConfig &config, const nr::
     std::string prefix = config.nsNamePrefix.value_or(cons::TunNamePrefix);
     std::string identity = config.supi.has_value() ? config.supi->value : config.getNodeName();
     std::string apn = pduSession.apn.value_or("default");
-    return SanitizeNamespaceToken(prefix) + "-" + SanitizeNamespaceToken(identity) + "-" +
-           SanitizeNamespaceToken(apn);
+    // Include the PSI so each PDU session gets a distinct namespace, even on the same APN.
+    return SanitizeNamespaceToken(prefix) + "-" + SanitizeNamespaceToken(identity) + "-" + SanitizeNamespaceToken(apn) +
+           "-psi" + std::to_string(pduSession.psi);
 }
 
 namespace nr::ue
@@ -228,7 +229,7 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
     }
 
     int fd = tun::TunAllocate(requestedName.c_str(), allocatedName, nsName, m_base->config->useNamespace, error);
-    if (fd == 0 || error.length() > 0)
+    if (fd < 0 || error.length() > 0)
     {
         m_logger->err("TUN allocation failure [%s]", error.c_str());
         return;
@@ -255,11 +256,12 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
     task->start();
 
     if (m_base->config->useNamespace)
-        m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up in namespace[%s].",
-                       pduSession->psi, allocatedName.c_str(), ipAddress.c_str(), nsName.c_str());
+        m_logger->info(
+            "Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up in namespace[%s].",
+            pduSession->psi, allocatedName.c_str(), ipAddress.c_str(), nsName.c_str());
     else
-        m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up.", pduSession->psi,
-                       allocatedName.c_str(), ipAddress.c_str());
+        m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up.",
+                       pduSession->psi, allocatedName.c_str(), ipAddress.c_str());
 }
 
 } // namespace nr::ue

--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -9,6 +9,7 @@
 #include "task.hpp"
 #include "cmd_handler.hpp"
 #include <cctype>
+#include <unistd.h>
 #include <lib/nas/utils.hpp>
 #include <ue/nas/task.hpp>
 #include <ue/rls/task.hpp>
@@ -240,6 +241,12 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
     if (!r || error.length() > 0)
     {
         m_logger->err("TUN configuration failure [%s]", error.c_str());
+        close(fd);
+        if (m_base->config->useNamespace)
+        {
+            std::string cleanupError{};
+            tun::TunCleanup(allocatedName, nsName, m_base->config->useNamespace, cleanupError);
+        }
         return;
     }
 

--- a/src/ue/app/task.cpp
+++ b/src/ue/app/task.cpp
@@ -8,6 +8,7 @@
 
 #include "task.hpp"
 #include "cmd_handler.hpp"
+#include <cctype>
 #include <lib/nas/utils.hpp>
 #include <ue/nas/task.hpp>
 #include <ue/rls/task.hpp>
@@ -17,6 +18,34 @@
 
 static constexpr const int SWITCH_OFF_TIMER_ID = 1;
 static constexpr const int SWITCH_OFF_DELAY = 500;
+
+static std::string SanitizeNamespaceToken(const std::string &value)
+{
+    std::string sanitized;
+    sanitized.reserve(value.size());
+
+    for (char ch : value)
+    {
+        if (std::isalnum(static_cast<unsigned char>(ch)) || ch == '-' || ch == '_' || ch == '.')
+            sanitized.push_back(ch);
+        else
+            sanitized.push_back('-');
+    }
+
+    if (sanitized.empty())
+        return "default";
+
+    return sanitized;
+}
+
+static std::string BuildNamespaceName(const nr::ue::UeConfig &config, const nr::ue::PduSession &pduSession)
+{
+    std::string prefix = config.nsNamePrefix.value_or(cons::TunNamePrefix);
+    std::string identity = config.supi.has_value() ? config.supi->value : config.getNodeName();
+    std::string apn = pduSession.apn.value_or("default");
+    return SanitizeNamespaceToken(prefix) + "-" + SanitizeNamespaceToken(identity) + "-" +
+           SanitizeNamespaceToken(apn);
+}
 
 namespace nr::ue
 {
@@ -182,12 +211,22 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
     std::string error{}, allocatedName{};
     std::string requestedName = cons::TunNamePrefix;
     std::string requestedNetmask = cons::TunNetmask;
+    std::string nsName{};
     if (m_base->config->tunName.has_value())
         requestedName = *m_base->config->tunName;
     if (m_base->config->tunNetmask.has_value())
         requestedNetmask = *m_base->config->tunNetmask;
-    
-    int fd = tun::TunAllocate(requestedName.c_str(), allocatedName, error);
+    if (m_base->config->useNamespace)
+    {
+        nsName = BuildNamespaceName(*m_base->config, *pduSession);
+        if (nsName.size() > 255)
+        {
+            m_logger->err("Connection could not setup. Namespace name is too long [%s].", nsName.c_str());
+            return;
+        }
+    }
+
+    int fd = tun::TunAllocate(requestedName.c_str(), allocatedName, nsName, m_base->config->useNamespace, error);
     if (fd == 0 || error.length() > 0)
     {
         m_logger->err("TUN allocation failure [%s]", error.c_str());
@@ -196,19 +235,24 @@ void UeAppTask::setupTunInterface(const PduSession *pduSession)
 
     std::string ipAddress = utils::OctetStringToIp(pduSession->pduAddress->pduAddressInformation);
 
-    bool r = tun::TunConfigure(allocatedName, ipAddress, requestedNetmask, cons::TunMtu, m_base->config->configureRouting, error);
+    bool r = tun::TunConfigure(allocatedName, ipAddress, requestedNetmask, cons::TunMtu, nsName,
+                               m_base->config->useNamespace, m_base->config->configureRouting, error);
     if (!r || error.length() > 0)
     {
         m_logger->err("TUN configuration failure [%s]", error.c_str());
         return;
     }
 
-    auto *task = new TunTask(m_base, psi, fd);
+    auto *task = new TunTask(m_base, psi, fd, allocatedName, nsName, m_base->config->useNamespace);
     m_tunTasks[psi] = task;
     task->start();
 
-    m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up.", pduSession->psi,
-                   allocatedName.c_str(), ipAddress.c_str());
+    if (m_base->config->useNamespace)
+        m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up in namespace[%s].",
+                       pduSession->psi, allocatedName.c_str(), ipAddress.c_str(), nsName.c_str());
+    else
+        m_logger->info("Connection setup for PDU session[%d] is successful, TUN interface[%s, %s] is up.", pduSession->psi,
+                       allocatedName.c_str(), ipAddress.c_str());
 }
 
 } // namespace nr::ue

--- a/src/ue/tun/config.cpp
+++ b/src/ue/tun/config.cpp
@@ -476,11 +476,13 @@ int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, 
             throw LibError("Invalid namespace name.");
         }
 
+        bool namespaceCreated = false;
         try
         {
-            // Remove any stale namespace left over from a previous crash so 'ip netns add' succeeds.
-            ExecLoose("ip netns delete " + namespaceName);
+            // Do not delete a pre-existing namespace: the name is unique per UE/APN/PSI, so it may
+            // belong to another running UE rather than being a stale leftover.
             ExecStrict("ip netns add " + namespaceName);
+            namespaceCreated = true;
             SaveNamespaceForDeletion(namespaceName);
             ExecLoose("ip netns exec " + namespaceName + " ip link set lo up");
             ExecStrict("ip link set " + std::string(tunName) + " netns " + namespaceName);
@@ -488,10 +490,13 @@ int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, 
         }
         catch (...)
         {
-            // Roll back the partially created state before propagating the failure.
+            // Roll back only what we created: close the fd and, if we added the namespace, remove it.
             close(fd);
-            ExecLoose("ip netns delete " + namespaceName);
-            RemoveSavedNamespace(namespaceName);
+            if (namespaceCreated)
+            {
+                ExecLoose("ip netns delete " + namespaceName);
+                RemoveSavedNamespace(namespaceName);
+            }
             throw;
         }
     }

--- a/src/ue/tun/config.cpp
+++ b/src/ue/tun/config.cpp
@@ -11,7 +11,6 @@
 #include <arpa/inet.h>
 #include <array>
 #include <cerrno>
-#include <csignal>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -37,6 +36,7 @@
 #include <unistd.h>
 #include <vector>
 
+#include <lib/app/base_app.hpp>
 #include <utils/libc_error.hpp>
 
 #define ROUTING_TABLE_PREFIX "rt_"
@@ -44,6 +44,9 @@
 #define MAX_NAMESPACE_NAME_LEN 256
 
 static std::mutex configMutex;
+// Guards the namespace deletion registry only. Kept separate from configMutex (which is held across
+// blocking 'ip' executions) so the at-exit cleanup never blocks on a long-running command.
+static std::mutex namespaceRegistryMutex;
 static char namespacesToDelete[MAX_INTERFACE_COUNT][MAX_NAMESPACE_NAME_LEN];
 static int namespacesToDeleteCount = 0;
 static int initialized = 0;
@@ -128,6 +131,8 @@ static int NetmaskToPrefixLength(const std::string &netmask)
 
 static void SaveNamespaceForDeletion(const std::string &nsName)
 {
+    const std::lock_guard<std::mutex> lock(namespaceRegistryMutex);
+
     if (!IsValidNamespaceName(nsName) || namespacesToDeleteCount >= MAX_INTERFACE_COUNT)
         return;
 
@@ -142,6 +147,8 @@ static void SaveNamespaceForDeletion(const std::string &nsName)
 
 static void RemoveSavedNamespace(const std::string &nsName)
 {
+    const std::lock_guard<std::mutex> lock(namespaceRegistryMutex);
+
     for (int i = 0; i < namespacesToDeleteCount; ++i)
     {
         if (std::strcmp(namespacesToDelete[i], nsName.c_str()) == 0)
@@ -156,20 +163,18 @@ static void RemoveSavedNamespace(const std::string &nsName)
 
 static void DeleteSavedNamespaces()
 {
-    for (int i = 0; i < namespacesToDeleteCount; ++i)
-        ExecLoose("ip netns delete " + std::string(namespacesToDelete[i]));
-    namespacesToDeleteCount = 0;
-}
+    // Snapshot the registry under the lock, then run the deletions outside it so we never hold a
+    // mutex while a blocking 'ip' command executes.
+    std::vector<std::string> namespaces;
+    {
+        const std::lock_guard<std::mutex> lock(namespaceRegistryMutex);
+        for (int i = 0; i < namespacesToDeleteCount; ++i)
+            namespaces.emplace_back(namespacesToDelete[i]);
+        namespacesToDeleteCount = 0;
+    }
 
-static void SigHandler(int signum)
-{
-    DeleteSavedNamespaces();
-    _exit(128 + signum);
-}
-
-static void ExitHandler()
-{
-    DeleteSavedNamespaces();
+    for (const auto &ns : namespaces)
+        ExecLoose("ip netns delete " + ns);
 }
 
 static void InitializeTunHandling()
@@ -177,10 +182,9 @@ static void InitializeTunHandling()
     if (initialized)
         return;
 
-    atexit(ExitHandler);
-    signal(SIGINT, SigHandler);
-    signal(SIGTERM, SigHandler);
-    signal(SIGHUP, SigHandler);
+    // Reuse the framework's signal/exit handling instead of installing our own handlers, which would
+    // otherwise override app::BaseSignalHandler. RunAtExit is the same mechanism proc_table uses.
+    app::RunAtExit(DeleteSavedNamespaces);
     initialized = 1;
 }
 
@@ -472,11 +476,24 @@ int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, 
             throw LibError("Invalid namespace name.");
         }
 
-        ExecStrict("ip netns add " + namespaceName);
-        SaveNamespaceForDeletion(namespaceName);
-        ExecLoose("ip netns exec " + namespaceName + " ip link set lo up");
-        ExecStrict("ip link set " + std::string(tunName) + " netns " + namespaceName);
-        ExecStrict("ip netns exec " + namespaceName + " ip link show " + std::string(tunName));
+        try
+        {
+            // Remove any stale namespace left over from a previous crash so 'ip netns add' succeeds.
+            ExecLoose("ip netns delete " + namespaceName);
+            ExecStrict("ip netns add " + namespaceName);
+            SaveNamespaceForDeletion(namespaceName);
+            ExecLoose("ip netns exec " + namespaceName + " ip link set lo up");
+            ExecStrict("ip link set " + std::string(tunName) + " netns " + namespaceName);
+            ExecStrict("ip netns exec " + namespaceName + " ip link show " + std::string(tunName));
+        }
+        catch (...)
+        {
+            // Roll back the partially created state before propagating the failure.
+            close(fd);
+            ExecLoose("ip netns delete " + namespaceName);
+            RemoveSavedNamespace(namespaceName);
+            throw;
+        }
     }
 
     *allocatedName = strdup(tunName);

--- a/src/ue/tun/config.cpp
+++ b/src/ue/tun/config.cpp
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include <array>
 #include <cerrno>
+#include <csignal>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -40,8 +41,12 @@
 
 #define ROUTING_TABLE_PREFIX "rt_"
 #define MAX_INTERFACE_COUNT 1024
+#define MAX_NAMESPACE_NAME_LEN 256
 
 static std::mutex configMutex;
+static char namespacesToDelete[MAX_INTERFACE_COUNT][MAX_NAMESPACE_NAME_LEN];
+static int namespacesToDeleteCount = 0;
+static int initialized = 0;
 
 static int ExecOutput(const char *cmd, std::string &output)
 {
@@ -79,6 +84,104 @@ static std::string ExecStrict(const std::string &cmd)
                        "Command execution failure");
     }
     return output;
+}
+
+static std::string ExecLoose(const std::string &cmd)
+{
+    std::string output;
+    if (ExecOutput(cmd.c_str(), output))
+        return "";
+    return output;
+}
+
+static bool IsValidNamespaceName(const std::string &nsName)
+{
+    return !nsName.empty() && nsName.size() < MAX_NAMESPACE_NAME_LEN && nsName.find('/') == std::string::npos;
+}
+
+static int NetmaskToPrefixLength(const std::string &netmask)
+{
+    in_addr addr{};
+    if (inet_pton(AF_INET, netmask.c_str(), &addr) != 1)
+        return -1;
+
+    uint32_t mask = ntohl(addr.s_addr);
+    int prefixLength = 0;
+    bool zeroSeen = false;
+    for (int bit = 31; bit >= 0; --bit)
+    {
+        bool set = (mask & (1u << bit)) != 0;
+        if (set)
+        {
+            if (zeroSeen)
+                return -1;
+            ++prefixLength;
+        }
+        else
+        {
+            zeroSeen = true;
+        }
+    }
+
+    return prefixLength;
+}
+
+static void SaveNamespaceForDeletion(const std::string &nsName)
+{
+    if (!IsValidNamespaceName(nsName) || namespacesToDeleteCount >= MAX_INTERFACE_COUNT)
+        return;
+
+    for (int i = 0; i < namespacesToDeleteCount; ++i)
+    {
+        if (std::strcmp(namespacesToDelete[i], nsName.c_str()) == 0)
+            return;
+    }
+
+    std::snprintf(namespacesToDelete[namespacesToDeleteCount++], MAX_NAMESPACE_NAME_LEN, "%s", nsName.c_str());
+}
+
+static void RemoveSavedNamespace(const std::string &nsName)
+{
+    for (int i = 0; i < namespacesToDeleteCount; ++i)
+    {
+        if (std::strcmp(namespacesToDelete[i], nsName.c_str()) == 0)
+        {
+            for (int j = i; j < namespacesToDeleteCount - 1; ++j)
+                std::snprintf(namespacesToDelete[j], MAX_NAMESPACE_NAME_LEN, "%s", namespacesToDelete[j + 1]);
+            --namespacesToDeleteCount;
+            return;
+        }
+    }
+}
+
+static void DeleteSavedNamespaces()
+{
+    for (int i = 0; i < namespacesToDeleteCount; ++i)
+        ExecLoose("ip netns delete " + std::string(namespacesToDelete[i]));
+    namespacesToDeleteCount = 0;
+}
+
+static void SigHandler(int signum)
+{
+    DeleteSavedNamespaces();
+    _exit(128 + signum);
+}
+
+static void ExitHandler()
+{
+    DeleteSavedNamespaces();
+}
+
+static void InitializeTunHandling()
+{
+    if (initialized)
+        return;
+
+    atexit(ExitHandler);
+    signal(SIGINT, SigHandler);
+    signal(SIGTERM, SigHandler);
+    signal(SIGHUP, SigHandler);
+    initialized = 1;
 }
 
 static const char *NextInterfaceName(const std::string &prefix)
@@ -323,10 +426,13 @@ static void AddIpRoutes(const std::string &if_name, const std::string &table_nam
 namespace nr::ue::tun
 {
 
-int AllocateTun(const char *ifPrefix, char **allocatedName)
+int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, bool useNamespace)
 {
     // acquire the configuration lock
     const std::lock_guard<std::mutex> lock(configMutex);
+
+    if (useNamespace)
+        InitializeTunHandling();
 
     const char *ifName = NextInterfaceName(ifPrefix);
     if (!ifName)
@@ -357,14 +463,49 @@ int AllocateTun(const char *ifPrefix, char **allocatedName)
     if (strcmp(tunName, ifName) != 0)
         throw LibError("TUN interface name could not be allocated.");
 
+    if (useNamespace)
+    {
+        std::string namespaceName = nsName ? nsName : "";
+        if (!IsValidNamespaceName(namespaceName))
+        {
+            close(fd);
+            throw LibError("Invalid namespace name.");
+        }
+
+        ExecStrict("ip netns add " + namespaceName);
+        SaveNamespaceForDeletion(namespaceName);
+        ExecLoose("ip netns exec " + namespaceName + " ip link set lo up");
+        ExecStrict("ip link set " + std::string(tunName) + " netns " + namespaceName);
+        ExecStrict("ip netns exec " + namespaceName + " ip link show " + std::string(tunName));
+    }
+
     *allocatedName = strdup(tunName);
     return fd;
 }
 
-void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, int mtu, bool configureRoute)
+void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, int mtu, const char *nsName,
+                  bool useNamespace, bool configureRoute)
 {
     // acquire the configuration lock
     const std::lock_guard<std::mutex> lock(configMutex);
+
+    if (useNamespace)
+    {
+        std::string namespaceName = nsName ? nsName : "";
+        int prefixLength = NetmaskToPrefixLength(netmask ? netmask : "");
+        if (!IsValidNamespaceName(namespaceName))
+            throw LibError("Invalid namespace name.");
+        if (prefixLength < 0)
+            throw LibError("Invalid netmask.");
+
+        ExecStrict("ip netns exec " + namespaceName + " ip addr add " + std::string(ipAddr) + "/" +
+                   std::to_string(prefixLength) + " dev " + tunName);
+        ExecStrict("ip netns exec " + namespaceName + " ip link set " + tunName + " mtu " + std::to_string(mtu));
+        ExecStrict("ip netns exec " + namespaceName + " ip link set " + tunName + " up");
+        if (configureRoute)
+            ExecStrict("ip netns exec " + namespaceName + " ip route replace default dev " + tunName);
+        return;
+    }
 
     TunSetIpAndUp(tunName, ipAddr, netmask, mtu);
     if (configureRoute)
@@ -377,6 +518,18 @@ void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, 
         RemoveExistingIpRoutes(tunName, table_name);
         AddIpRoutes(tunName, table_name);
     }
+}
+
+void CleanupTun(const char *tunName, const char *nsName, bool useNamespace)
+{
+    const std::lock_guard<std::mutex> lock(configMutex);
+
+    if (!useNamespace || nsName == nullptr || *nsName == '\0')
+        return;
+
+    std::string namespaceName = nsName;
+    ExecLoose("ip netns delete " + namespaceName);
+    RemoveSavedNamespace(namespaceName);
 }
 
 } // namespace nr::ue::tun

--- a/src/ue/tun/config.cpp
+++ b/src/ue/tun/config.cpp
@@ -129,6 +129,22 @@ static int NetmaskToPrefixLength(const std::string &netmask)
     return prefixLength;
 }
 
+static bool LinksHaveNonLoopback(const std::string &linkOutput)
+{
+    // 'ip -o link show' prints one interface per line as "<index>: <name>: ...".
+    std::stringstream ss(linkOutput);
+    std::string line;
+    while (std::getline(ss, line))
+    {
+        std::string index, name;
+        std::stringstream ls(line);
+        ls >> index >> name;
+        if (!name.empty() && name != "lo:")
+            return true;
+    }
+    return false;
+}
+
 static void SaveNamespaceForDeletion(const std::string &nsName)
 {
     const std::lock_guard<std::mutex> lock(namespaceRegistryMutex);
@@ -476,11 +492,23 @@ int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, 
             throw LibError("Invalid namespace name.");
         }
 
+        // If the namespace already exists, reclaim it only when stale. A UE's TUN device is
+        // non-persistent and dies with the process, so a crashed UE leaves a namespace with only 'lo';
+        // one that still holds a device belongs to a live UE and must not be touched.
+        std::string existingLinks = ExecLoose("ip netns exec " + namespaceName + " ip -o link show");
+        if (!existingLinks.empty())
+        {
+            if (LinksHaveNonLoopback(existingLinks))
+            {
+                close(fd);
+                throw LibError("Network namespace already in use: " + namespaceName);
+            }
+            ExecLoose("ip netns delete " + namespaceName);
+        }
+
         bool namespaceCreated = false;
         try
         {
-            // Do not delete a pre-existing namespace: the name is unique per UE/APN/PSI, so it may
-            // belong to another running UE rather than being a stale leftover.
             ExecStrict("ip netns add " + namespaceName);
             namespaceCreated = true;
             SaveNamespaceForDeletion(namespaceName);

--- a/src/ue/tun/config.hpp
+++ b/src/ue/tun/config.hpp
@@ -15,7 +15,9 @@
 namespace nr::ue::tun
 {
 
-int AllocateTun(const char *ifPrefix, char **allocatedName);
-void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, int mtu, bool configureRoute);
+int AllocateTun(const char *ifPrefix, char **allocatedName, const char *nsName, bool useNamespace);
+void ConfigureTun(const char *tunName, const char *ipAddr, const char *netmask, int mtu, const char *nsName,
+				  bool useNamespace, bool configureRoute);
+void CleanupTun(const char *tunName, const char *nsName, bool useNamespace);
 
 } // namespace nr::ue::tun

--- a/src/ue/tun/task.cpp
+++ b/src/ue/tun/task.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <ue/app/task.hpp>
 #include <ue/nts.hpp>
+#include <ue/tun/tun.hpp>
 #include <unistd.h>
 #include <utils/libc_error.hpp>
 #include <utils/scoped_thread.hpp>
@@ -74,8 +75,11 @@ static void ReceiverThread(ReceiverArgs *args)
 namespace nr::ue
 {
 
-ue::TunTask::TunTask(TaskBase *base, int psi, int fd) : m_base{base}, m_psi{psi}, m_fd{fd}, m_receiver{}
+ue::TunTask::TunTask(TaskBase *base, int psi, int fd, std::string tunName, std::string nsName, bool useNamespace)
+        : m_base{base}, m_psi{psi}, m_fd{fd}, m_name{std::move(tunName)}, m_nsName{std::move(nsName)},
+            m_useNamespace{useNamespace}, m_receiver{}
 {
+    m_logger = m_base->logBase->makeUniqueLogger(m_base->config->getLoggerPrefix() + "tun");
 }
 
 void TunTask::onStart()
@@ -92,6 +96,13 @@ void TunTask::onQuit()
 {
     delete m_receiver;
     ::close(m_fd);
+
+    if (m_useNamespace && !m_nsName.empty())
+    {
+        std::string error;
+        if (!tun::TunCleanup(m_name, m_nsName, m_useNamespace, error))
+            m_logger->warn("Namespace cleanup failed for [%s]: %s", m_nsName.c_str(), error.c_str());
+    }
 }
 
 void TunTask::onLoop()

--- a/src/ue/tun/task.hpp
+++ b/src/ue/tun/task.hpp
@@ -26,12 +26,16 @@ class TunTask : public NtsTask
     TaskBase *m_base;
     int m_psi;
     int m_fd;
+    std::string m_name;
+    std::string m_nsName;
+    bool m_useNamespace;
+    std::unique_ptr<Logger> m_logger;
     ScopedThread *m_receiver;
 
     friend class UeCmdHandler;
 
   public:
-    explicit TunTask(TaskBase *taskBase, int psi, int fd);
+    explicit TunTask(TaskBase *taskBase, int psi, int fd, std::string tunName, std::string nsName, bool useNamespace);
     ~TunTask() override = default;
 
   protected:

--- a/src/ue/tun/tun.cpp
+++ b/src/ue/tun/tun.cpp
@@ -13,14 +13,16 @@
 namespace nr::ue::tun
 {
 
-int TunAllocate(const char *namePrefix, std::string &allocatedName, std::string &error)
+int TunAllocate(const char *namePrefix, std::string &allocatedName, const std::string &nsName, bool useNamespace,
+                std::string &error)
 {
     int fd;
     char *name = nullptr;
     try
     {
-        fd = tun::AllocateTun(namePrefix, &name);
+        fd = tun::AllocateTun(namePrefix, &name, nsName.c_str(), useNamespace);
         allocatedName = std::string{name};
+        free(name);
     }
     catch (const LibError &e)
     {
@@ -32,11 +34,28 @@ int TunAllocate(const char *namePrefix, std::string &allocatedName, std::string 
     return fd;
 }
 
-bool TunConfigure(const std::string &tunName, const std::string &ipAddress, const std::string &netmask, int mtu, bool configureRouting, std::string &error)
+bool TunConfigure(const std::string &tunName, const std::string &ipAddress, const std::string &netmask, int mtu,
+                  const std::string &nsName, bool useNamespace, bool configureRouting, std::string &error)
 {
     try
     {
-        tun::ConfigureTun(tunName.c_str(), ipAddress.c_str(), netmask.c_str(), mtu, configureRouting);
+        tun::ConfigureTun(tunName.c_str(), ipAddress.c_str(), netmask.c_str(), mtu, nsName.c_str(), useNamespace,
+                          configureRouting);
+    }
+    catch (const LibError &e)
+    {
+        error = e.what();
+        return false;
+    }
+
+    return true;
+}
+
+bool TunCleanup(const std::string &tunName, const std::string &nsName, bool useNamespace, std::string &error)
+{
+    try
+    {
+        tun::CleanupTun(tunName.c_str(), nsName.c_str(), useNamespace);
     }
     catch (const LibError &e)
     {

--- a/src/ue/tun/tun.cpp
+++ b/src/ue/tun/tun.cpp
@@ -28,7 +28,7 @@ int TunAllocate(const char *namePrefix, std::string &allocatedName, const std::s
     {
         error = e.what();
         allocatedName = "";
-        return 0;
+        return -1;
     }
 
     return fd;

--- a/src/ue/tun/tun.hpp
+++ b/src/ue/tun/tun.hpp
@@ -13,7 +13,10 @@
 namespace nr::ue::tun
 {
 
-int TunAllocate(const char *namePrefix, std::string &allocatedName, std::string &error);
-bool TunConfigure(const std::string &tunName, const std::string &ipAddress, const std::string &netmask, int mtu, bool configureRouting, std::string &error);
+int TunAllocate(const char *namePrefix, std::string &allocatedName, const std::string &nsName, bool useNamespace,
+				std::string &error);
+bool TunConfigure(const std::string &tunName, const std::string &ipAddress, const std::string &netmask, int mtu,
+				  const std::string &nsName, bool useNamespace, bool configureRouting, std::string &error);
+bool TunCleanup(const std::string &tunName, const std::string &nsName, bool useNamespace, std::string &error);
 
 } // namespace nr::ue::tun

--- a/src/ue/types.hpp
+++ b/src/ue/types.hpp
@@ -112,6 +112,8 @@ struct UeConfig
     NetworkSlice configuredNssai{};
     std::optional<std::string> tunName{};
     std::optional<std::string> tunNetmask{};
+    bool useNamespace{false};
+    std::optional<std::string> nsNamePrefix{};
 
     struct
     {


### PR DESCRIPTION
Add an opt-in network namespace mode for UE TUN interfaces. When useNamespace is enabled in the UE config, the TUN interface is created inside a dedicated Linux network namespace derived from the UE identity and APN. The namespace is automatically cleaned up on normal teardown, and best-effort cleanup is performed on process exit and termination signals.

New config fields:
  - useNamespace (bool, default false)
  - nsNamePrefix (optional string)

Namespace mode is off by default. The existing non-namespace TUN path is unchanged.

Running multiple UEs with isolated Linux network state is useful for test environments that need per-UE routing separation without external manual namespace management.