### PR TITLE
Add NR-NTN TAI Information extension to UserLocationInformation

### DIFF
--- a/config/custom-gnb.yaml
+++ b/config/custom-gnb.yaml
@@ -21,3 +21,8 @@ slices:
 
 # Indicates whether or not SCTP stream number errors should be ignored.
 ignoreStreamIds: true
+
+# Cell access type. When set to one of the satellite types (nr-leo, nr-meo,
+# nr-geo, nr-othersat), the gNB attaches the NR-NTN TAI Information extension
+# to every UserLocationInformationNR it sends to the AMF. Defaults to "nr".
+cellAccessType: nr

--- a/config/free5gc-gnb.yaml
+++ b/config/free5gc-gnb.yaml
@@ -21,3 +21,8 @@ slices:
 
 # Indicates whether or not SCTP stream number errors should be ignored.
 ignoreStreamIds: true
+
+# Cell access type. When set to one of the satellite types (nr-leo, nr-meo,
+# nr-geo, nr-othersat), the gNB attaches the NR-NTN TAI Information extension
+# to every UserLocationInformationNR it sends to the AMF. Defaults to "nr".
+cellAccessType: nr

--- a/config/open5gs-gnb.yaml
+++ b/config/open5gs-gnb.yaml
@@ -20,3 +20,8 @@ slices:
 
 # Indicates whether or not SCTP stream number errors should be ignored.
 ignoreStreamIds: true
+
+# Cell access type. When set to one of the satellite types (nr-leo, nr-meo,
+# nr-geo, nr-othersat), the gNB attaches the NR-NTN TAI Information extension
+# to every UserLocationInformationNR it sends to the AMF. Defaults to "nr".
+cellAccessType: nr

--- a/src/gnb.cpp
+++ b/src/gnb.cpp
@@ -77,6 +77,24 @@ static nr::gnb::GnbConfig *ReadConfigYaml()
         result->nssai.slices.push_back(s);
     }
 
+    if (yaml::HasField(config, "cellAccessType"))
+    {
+        auto value = yaml::GetString(config, "cellAccessType", 1, 16);
+        if (value == "nr")
+            result->cellAccessType = nr::gnb::ECellAccessType::TerrestrialNr;
+        else if (value == "nr-leo")
+            result->cellAccessType = nr::gnb::ECellAccessType::NrLeo;
+        else if (value == "nr-meo")
+            result->cellAccessType = nr::gnb::ECellAccessType::NrMeo;
+        else if (value == "nr-geo")
+            result->cellAccessType = nr::gnb::ECellAccessType::NrGeo;
+        else if (value == "nr-othersat")
+            result->cellAccessType = nr::gnb::ECellAccessType::NrOthersat;
+        else
+            throw std::runtime_error("Invalid 'cellAccessType' value '" + value +
+                                     "'. Valid values: nr, nr-leo, nr-meo, nr-geo, nr-othersat");
+    }
+
     return result;
 }
 

--- a/src/gnb/ngap/transport.cpp
+++ b/src/gnb/ngap/transport.cpp
@@ -19,9 +19,13 @@
 #include <asn/ngap/ASN_NGAP_AMF-UE-NGAP-ID.h>
 #include <asn/ngap/ASN_NGAP_InitiatingMessage.h>
 #include <asn/ngap/ASN_NGAP_NGAP-PDU.h>
+#include <asn/ngap/ASN_NGAP_NRNTNTAIInformation.h>
+#include <asn/ngap/ASN_NGAP_ProtocolExtensionContainer.h>
+#include <asn/ngap/ASN_NGAP_ProtocolExtensionField.h>
 #include <asn/ngap/ASN_NGAP_ProtocolIE-Field.h>
 #include <asn/ngap/ASN_NGAP_RAN-UE-NGAP-ID.h>
 #include <asn/ngap/ASN_NGAP_SuccessfulOutcome.h>
+#include <asn/ngap/ASN_NGAP_TACListInNRNTN.h>
 #include <asn/ngap/ASN_NGAP_UnsuccessfulOutcome.h>
 #include <asn/ngap/ASN_NGAP_UserLocationInformation.h>
 #include <asn/ngap/ASN_NGAP_UserLocationInformationNR.h>
@@ -179,6 +183,37 @@ void NgapTask::sendNgapUeAssociated(int ueId, ASN_NGAP_NGAP_PDU *pdu)
                 ngap_utils::ToPlmnAsn_Ref(m_base->config->plmn, nr->tAI.pLMNIdentity);
                 asn::SetOctetString3(nr->tAI.tAC, octet3{m_base->config->tac});
                 asn::SetOctetString4(*nr->timeStamp, octet4{utils::CurrentTimeStamp().seconds32()});
+
+                // For NTN cells, attach the NR-NTN TAI Information extension (38.413 §9.3.1.16a).
+                if (IsNtn(m_base->config->cellAccessType))
+                {
+                    // iE_Extensions is generically typed; asn1c emits a specific container
+                    // type (named after its SEQUENCE position in the schema) which must be
+                    // cast to the generic pointer.
+                    auto *extContainer = asn::New<ASN_NGAP_ProtocolExtensionContainer_174P368>();
+                    nr->iE_Extensions = reinterpret_cast<ASN_NGAP_ProtocolExtensionContainer *>(extContainer);
+
+                    auto *ext = asn::New<ASN_NGAP_UserLocationInformationNR_ExtIEs>();
+                    // The schema only exports id-NRNTNTAIInformation in the ProtocolIE-ID
+                    // table; the same numeric value is used as the extension id here.
+                    ext->id = static_cast<ASN_NGAP_ProtocolExtensionID_t>(
+                        ASN_NGAP_ProtocolIE_ID_id_NRNTNTAIInformation);
+                    ext->criticality = ASN_NGAP_Criticality_ignore;
+                    ext->extensionValue.present =
+                        ASN_NGAP_UserLocationInformationNR_ExtIEs__extensionValue_PR_NRNTNTAIInformation;
+
+                    auto &ntn = ext->extensionValue.choice.NRNTNTAIInformation;
+                    ngap_utils::ToPlmnAsn_Ref(m_base->config->plmn, ntn.servingPLMN);
+
+                    auto *tac = asn::New<ASN_NGAP_TAC_t>();
+                    asn::SetOctetString3(*tac, octet3{m_base->config->tac});
+                    ASN_SEQUENCE_ADD(&ntn.tACListInNRNTN.list, tac);
+
+                    // uELocationDerivedTACInNRNTN is intentionally absent: the simulator
+                    // has no UE ephemeris/location to derive a UE-side TAC.
+
+                    ASN_SEQUENCE_ADD(&extContainer->list, ext);
+                }
             });
     }
 

--- a/src/gnb/types.hpp
+++ b/src/gnb/types.hpp
@@ -300,6 +300,23 @@ struct GnbAmfConfig
     uint16_t port{};
 };
 
+// Cell access type, used to populate the NR-NTN TAI Information extension on
+// UserLocationInformation when the cell is on a satellite access type.
+enum class ECellAccessType
+{
+    TerrestrialNr,
+    NrLeo,
+    NrMeo,
+    NrGeo,
+    NrOthersat,
+};
+
+inline bool IsNtn(ECellAccessType type)
+{
+    return type == ECellAccessType::NrLeo || type == ECellAccessType::NrMeo ||
+           type == ECellAccessType::NrGeo || type == ECellAccessType::NrOthersat;
+}
+
 struct GnbConfig
 {
     /* Read from config file */
@@ -314,6 +331,7 @@ struct GnbConfig
     std::string gtpIp{};
     std::optional<std::string> gtpAdvertiseIp{};
     bool ignoreStreamIds{};
+    ECellAccessType cellAccessType{ECellAccessType::TerrestrialNr};
 
     /* Assigned by program */
     std::string name{};


### PR DESCRIPTION
For cells configured as a satellite RAT (`nr-leo` / `nr-meo` /
`nr-geo` / `nr-othersat`), attach the `NR-NTN-TAI-Information`
extension (3GPP TS 38.413 §9.3.1.16a) to the `UserLocationInformation`
IE that the gNB already emits via `sendNgapUeAssociated`.

Carries `servingPLMN` and `tACListInNRNTN`. `uELocationDerivedTACInNRNTN`
is omitted — the simulator has no UE ephemeris to derive it.

Cell access type is read from a new optional gNB YAML field:

```yaml
ratType: nr-geo  # nr (default), nr-leo, nr-meo, nr-geo, nr-othersat
```

Default `nr` preserves current behavior (no extension). +76 / −0
across 4 files.
