### PR TITLE
rls: forward SIGNAL_LOST to RRC task to clean up stale UE context

### DIFF
--- a/src/gnb/nts.hpp
+++ b/src/gnb/nts.hpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALİ GÜNGÖR.
+// Copyright (c) 2023 ALÄ° GÃNGÃR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.
@@ -37,10 +37,12 @@ struct NmGnbRlsToRrc : NtsMessage
     enum PR
     {
         SIGNAL_DETECTED,
+        SIGNAL_LOST,
         UPLINK_RRC,
     } present;
 
     // SIGNAL_DETECTED
+    // SIGNAL_LOST
     // UPLINK_RRC
     int ueId{};
 

--- a/src/gnb/nts.hpp
+++ b/src/gnb/nts.hpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALÄ° GÃNGÃR.
+// Copyright (c) 2023 ALİ GÜNGÖR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.

--- a/src/gnb/rls/task.cpp
+++ b/src/gnb/rls/task.cpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALİ GÜNGÖR.
+// Copyright (c) 2023 ALÄ° GÃNGÃR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.
@@ -54,6 +54,9 @@ void GnbRlsTask::onLoop()
         }
         case NmGnbRlsToRls::SIGNAL_LOST: {
             m_logger->debug("UE[%d] signal lost", w.ueId);
+            auto m = std::make_unique<NmGnbRlsToRrc>(NmGnbRlsToRrc::SIGNAL_LOST);
+            m->ueId = w.ueId;
+            m_base->rrcTask->push(std::move(m));
             break;
         }
         case NmGnbRlsToRls::UPLINK_DATA: {

--- a/src/gnb/rls/task.cpp
+++ b/src/gnb/rls/task.cpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALÄ° GÃNGÃR.
+// Copyright (c) 2023 ALİ GÜNGÖR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.

--- a/src/gnb/rrc/sap.cpp
+++ b/src/gnb/rrc/sap.cpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALİ GÜNGÖR.
+// Copyright (c) 2023 ALÄ° GÃNGÃR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.
@@ -21,6 +21,10 @@ void GnbRrcTask::handleRlsSapMessage(NmGnbRlsToRrc &msg)
     case NmGnbRlsToRrc::SIGNAL_DETECTED: {
         m_logger->debug("UE[%d] new signal detected", msg.ueId);
         triggerSysInfoBroadcast();
+        break;
+    }
+    case NmGnbRlsToRrc::SIGNAL_LOST: {
+        handleRadioLinkFailure(msg.ueId);
         break;
     }
     case NmGnbRlsToRrc::UPLINK_RRC: {

--- a/src/gnb/rrc/sap.cpp
+++ b/src/gnb/rrc/sap.cpp
@@ -1,6 +1,6 @@
 //
 // This file is a part of UERANSIM project.
-// Copyright (c) 2023 ALÄ° GÃNGÃR.
+// Copyright (c) 2023 ALİ GÜNGÖR.
 //
 // https://github.com/aligungr/UERANSIM/
 // See README, LICENSE, and CONTRIBUTING files for licensing details.


### PR DESCRIPTION
Fixes #780 — gNB radio link failure handling bug.

## Problem

After a radio link failure (RLF), the UE cannot reconnect without restarting
the gNB and core, because the gNB rejects the new RRC Setup Request with:

```
[rrc] [warning] Discarding RRC Setup Request, UE context already exists
```

## Root Cause

In `src/gnb/rls/task.cpp`, the `SIGNAL_LOST` case only logs the event — it
never forwards it to the RRC task:

```cpp
case NmGnbRlsToRls::SIGNAL_LOST: {
    m_logger->debug("UE[%d] signal lost", w.ueId);
    break;   // nothing sent to RRC
}
```

By contrast, `SIGNAL_DETECTED` correctly pushes a message to the RRC task.

Because no message reaches the RRC task, `GnbRrcTask::handleRadioLinkFailure()`
is never invoked, so `m_ueCtx.erase(ueId)` never runs. The stale UE context
persists. When the UE tries to reconnect, `tryFindUe(ueId)` finds the stale
entry and discards the new RRC Setup Request.

## Fix

Three small changes:

1. **`src/gnb/nts.hpp`** — add `SIGNAL_LOST` to the `NmGnbRlsToRrc::PR` enum
   so the message type exists.

2. **`src/gnb/rls/task.cpp`** — in the `SIGNAL_LOST` case, push
   `NmGnbRlsToRrc::SIGNAL_LOST` to the RRC task (mirroring how `SIGNAL_DETECTED`
   is already handled).

3. **`src/gnb/rrc/sap.cpp`** — handle `NmGnbRlsToRrc::SIGNAL_LOST` in
   `handleRlsSapMessage` by calling `handleRadioLinkFailure(msg.ueId)`.

`handleRadioLinkFailure` (already implemented in `handler.cpp`) then:
- Erases the stale UE context from `m_ueCtx`
- Notifies the NGAP task (which notifies GTP to release the UE context on the core side)

## Testing

Reproduced with UERANSIM gNB + UE on separate VMs against free5GC:

1. Start gNB, UE — registration and PDU session succeed
2. Simulate RLF (e.g., kill/restart the UE process or let signal timeout)
3. **Before fix:** UE reconnect fails with "UE context already exists"; requires
   full restart of gNB + core to recover
4. **After fix:** UE re-registers and re-establishes PDU session without any
   restart needed
